### PR TITLE
replacing not working curl download link

### DIFF
--- a/docs/configuration/nerd-fonts.md
+++ b/docs/configuration/nerd-fonts.md
@@ -18,7 +18,7 @@ Visit [this repo](https://github.com/ronniedroid/getnf) for an easy way to insta
 ### Curl Download
 ```bash
 mkdir -p ~/.local/share/fonts
-cd ~/.local/share/fonts && curl -fLo "Fira Code Regular Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/blob/master/patched-fonts/FiraCode/Regular/complete/Fira%20Code%20Regular%20Nerd%20Font%20Complete.otf
+cd ~/.local/share/fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
 ### TTF vs OTF


### PR DESCRIPTION
Current curl download link return `curl: (22) The requested URL returned error: 404`, replaced with a working one