### PR TITLE
Rnvimr plugin quick start doesn't work(3 errs)

### DIFF
--- a/docs/plugins/plugin-quickstart.md
+++ b/docs/plugins/plugin-quickstart.md
@@ -59,15 +59,11 @@ Save (`:w`), and Packer will autoinstall the new plugins.
 ```lua
 {
   "kevinhwang91/rnvimr",
-    cmd = "Rnvimr",
+    cmd = "RnvimrToggle",
     config = function()
-      -- Make Ranger replace netrw and be the file explorer
-      -- vim.g.rnvimr_ex_enable = 1
       vim.g.rnvimr_draw_border = 1
       vim.g.rnvimr_pick_enable = 1
       vim.g.rnvimr_bw_enable = 1
-      vim.api.nvim_set_keymap("n", "-", ":RnvimrToggle<CR>", { noremap = true, silent = true })
-      require("lv-rnvimr").config()
       end,
 },
 ```


### PR DESCRIPTION
`cmd="Rnvimr"` no longer works, changed to RnvimrToggle fixes
`vim.g.rvimr_ex_enable = 1` no longer works, since netrw is disabled by lvim default
`require("lv-rnvimr").config()` makes rnvimr throws err
remove set key maps, key map shouldn't be buried in packer config, it's hard for user to see, if they just copied and pasted, they will have no idea how did the key get set up.