### PR TITLE
Adding related plugins section to the languages

### DIFF
--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -79,7 +79,7 @@ lvim.builtin.which_key.mappings["P"] = {
   "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" 
 }
 ```
-Adding a key to a existing submenu. 
+Adding a key to an existing submenu. 
 ``` lua
 lvim.builtin.which_key.mappings["tP"] = { 
   "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" 

--- a/docs/languages/c_cpp.md
+++ b/docs/languages/c_cpp.md
@@ -53,3 +53,7 @@ lvim.lang.cpp.lsp.setup.cmd = { "<path to executable>", "arg1", "arg2" }
 ```
 
 `<LS identifier>` must be one supported by `nvim-lspconfig`. [List of available LSP  configs](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md)
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -21,3 +21,7 @@ The csharp language server OmniSharp supports formatting. Formatting is automati
 ```lua
 lvim.lang.cs.formatters = { { exe = "clang_format" } }
 ```
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -27,3 +27,7 @@
 ## Debugger
 
 (TODO)
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -55,3 +55,7 @@ More information in [TypeScript](/languages/typescript.html#lsp-settings).
 ## Debugger
 
 (TODO)
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -16,3 +16,7 @@ Pkg.instantiate()
 ```
 julia install.jl
 ```
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/powershell.md
+++ b/docs/languages/powershell.md
@@ -37,3 +37,7 @@ For more information about the language server configuration, refer to [nvim-lsp
 ## Formatters
 
 Formatting is supported by the PowerShell ES language server without additional configuration.
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -51,3 +51,7 @@ lvim.lang.python.linters = {
 local dap_install = require "dap-install"
 dap_install.config("python_dbg", {})
 ```
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -5,3 +5,7 @@
 The recommended way to install the language server for ruby is to do it locally, per project by either including it in your Gemfile or `gem install solargraph`.  
 
 `LspInstall ruby` works for basic cases but will fail silently for more complex projects.  This is a known [issue](https://github.com/LunarVim/LunarVim/issues/945)
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -1,1 +1,5 @@
 # Rust
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -62,3 +62,7 @@ E.g. modify the `root_dir` setup value:
 ```lua
 lvim.lang.typescript.lsp.setup["root_dir"] = <new value>
 ```
+
+## Related plugins
+
+(TODO)

--- a/docs/languages/vue.md
+++ b/docs/languages/vue.md
@@ -43,3 +43,7 @@ The selected linter must be installed separately.
 ```lua
 :NlspConfig vuels
 ```
+
+## Related plugins
+
+(TODO)


### PR DESCRIPTION
There are a lot of language specific plugins which currently exists in the "plugins" section. I think it would be better to either have the language specific ones in the plugin section, or have them in both places. 