### PR TITLE
Update option to set leader

### DIFF
--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -123,7 +123,7 @@ lvim.builtin.which_key.mappings = {
 The default leader key is `Space`.  This can be changed with the following
 
 ```lua
-lvim.leader_key = "space"
+lvim.leader = "space"
 ```
 
 ## Cursor Movement


### PR DESCRIPTION
Seems to be just `leader` now: https://github.com/LunarVim/LunarVim/blob/rolling/lua/keymappings.lua#L178