### PR TITLE
Added some moore documentation to the autocommand

### DIFF
--- a/docs/configuration/05-autocommands.md
+++ b/docs/configuration/05-autocommands.md
@@ -9,3 +9,10 @@ lvim.autocommands.custom_groups = {
   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
 }
 ```
+Using "*" will make the autocommand run in any file. 
+Autocommands runs console commands, in order to use vim commands, put the mode in front of the command
+``` lua
+lvim.autocommands.custom_groups = {
+  {"InsertEnter", "*", ":normal zz"},
+ }
+```


### PR DESCRIPTION
the "*" for any file might be trivial, but it can still be nice to include. I first thought you could exclude the argument and it would work on all files, 
but that does not seem to be the case.