### PR TITLE
Update 02-keybindings.md

### DIFF
--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -37,7 +37,7 @@ vim.api.nvim_buf_set_keymap(0, '', 'cc', 'line(".") == 1 ? "cc" : "ggcc"', { nor
 ```
 
 ### LunarVim style
-Overwrite/augment the key-mappings provided by LunarVim for any mode, or leave empty to keep the defaults.
+Overwrite the default keybindings for a given mode
 ``` lua
  lvim.keys.normal_mode = {
    -- Page down/up


### PR DESCRIPTION
So apperently "lvim.keys.normal_mode" overwrites all keybindings, which was hard to understand from the description. The text 

> Overwrite/augment the key-mappings provided by LunarVim for any mode, or leave empty to keep the defaults

make it sound like you are merely adding to the keybindings, not completely removing them. Also the headings "Vim style", "Neovim style" and "Lunarvim style" makes it sound like they are all equivalent ways of achieving the same results, however the lunarvim style is the only one removing prior bindings. I would almost suggest removing the entire "Lunarvim style" section, as it is very rare anyone would want to remove all default bindings from lunarvim. 
That being said there might be something I am missing here lol