### PR TITLE
fix: typo on titlestring command

### DIFF
--- a/docs/configuration/01-settings.md
+++ b/docs/configuration/01-settings.md
@@ -32,7 +32,7 @@ vim.opt.swapfile = false -- creates a swapfile
 vim.opt.termguicolors = true -- set term gui colors (most terminals support this)
 vim.opt.timeoutlen = 100 -- time to wait for a mapped sequence to complete (in milliseconds)
 vim.opt.title = true -- set the title of window to the value of the titlestring
-vim.opt.opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
+vim.opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
 vim.opt.undodir = CACHE_PATH .. "/undo" -- set an undo directory
 vim.opt.undofile = true -- enable persistent undo
 vim.opt.updatetime = 300 -- faster completion


### PR DESCRIPTION
Hello! 
I fixed a very small typo in the Example options section.
