### PR TITLE
doc: formatting and linting for quick start

### DIFF
--- a/docs/02-after-install.md
+++ b/docs/02-after-install.md
@@ -24,6 +24,12 @@ To install a Language Server for your language:
 
 Sometimes the language server for your language will not have an obvious name.  For instance, the language server for ruby is solargraph.  Metals is the language server for scala, etc.  To find the corresponding language server for your language [look here](https://github.com/kabouzeid/nvim-lspinstall)
 
+## Formatting and Linting
+Formatting and Linting is not supported by some LSPs by default.
+This needs to be installed / configured separately. 
+
+See [languages](./languages/README.md) where each language with its formatting and linting can be addressed.
+
 ## Language Server Configuration
 To create a configuration file for your language server:
 


### PR DESCRIPTION
why:
currently it is a bit unclear (at least to me, that formatting is not supported out of the box.)

what:
At least in the quick start we explain or give a hint that this might need configuration / installation outside of Lunarvim

See:
https://github.com/LunarVim/LunarVim/issues/1600