### PR TITLE
Fixes undodir definition

### DIFF
--- a/docs/configuration/01-settings.md
+++ b/docs/configuration/01-settings.md
@@ -33,7 +33,7 @@ vim.opt.termguicolors = true -- set term gui colors (most terminals support this
 vim.opt.timeoutlen = 100 -- time to wait for a mapped sequence to complete (in milliseconds)
 vim.opt.title = true -- set the title of window to the value of the titlestring
 vim.opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
-vim.opt.undodir = ".cache/nvim/undo" -- set an undo directory
+vim.opt.undodir = vim.fn.stdpath "cache" .. "/undo"
 vim.opt.undofile = true -- enable persistent undo
 vim.opt.updatetime = 300 -- faster completion
 vim.opt.writebackup = false -- if a file is being edited by another program (or was written to file while editing with another program) it is not allowed to be edited

--- a/docs/configuration/01-settings.md
+++ b/docs/configuration/01-settings.md
@@ -33,7 +33,7 @@ vim.opt.termguicolors = true -- set term gui colors (most terminals support this
 vim.opt.timeoutlen = 100 -- time to wait for a mapped sequence to complete (in milliseconds)
 vim.opt.title = true -- set the title of window to the value of the titlestring
 vim.opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
-vim.opt.undodir = CACHE_PATH .. "/undo" -- set an undo directory
+vim.opt.undodir = ".cache/nvim/undo" -- set an undo directory
 vim.opt.undofile = true -- enable persistent undo
 vim.opt.updatetime = 300 -- faster completion
 vim.opt.writebackup = false -- if a file is being edited by another program (or was written to file while editing with another program) it is not allowed to be edited


### PR DESCRIPTION
This line doesn't work:
 ```lua
vim.opt.undodir = CACHE_PATH .. "/undo" -- set an undo directory
``` 

Through testing I could only make it work in this way (example):
```lua
vim.opt.undodir = ".cache/nvim/undo"
```
I'm proposing this change but please feel free to suggest a better way.

Thank you!