### PR TITLE
Update on Persistence extra plugin installation

### DIFF
--- a/docs/plugins/03-extra-plugins.md
+++ b/docs/plugins/03-extra-plugins.md
@@ -663,7 +663,7 @@ lvim.builtin.which_key.mappings["t"] = {
 ```lua
 {
   "folke/persistence.nvim",
-    event = "VimEnter",
+    event = "BufReadPre", -- this will only start session saving when an actual file was opened
     module = "persistence",
     config = function()
       require("persistence").setup {
@@ -677,11 +677,11 @@ lvim.builtin.which_key.mappings["t"] = {
 Also define keybindings in your `config.lua`
 
 ```lua
-  lvim.builtin.which_key.mappings["Q"]= {
-    name = "+Quit",
-    s = { "<cmd>lua require('persistence').load()<cr>", "Restore for current dir" },
-    l = { "<cmd>lua require('persistence').load(last=true)<cr>", "Restore last session" },
-    d = { "<cmd>lua require('persistence').stop()<cr>", "Quit without saving session" },
+  lvim.builtin.which_key.mappings["S"]= {
+    name = "Session",
+    c = { "<cmd>lua require('persistence').load()<cr>", "Restore last session for current dir" },
+    l = { "<cmd>lua require('persistence').load({ last = true })<cr>", "Restore last session" },
+    Q = { "<cmd>lua require('persistence').stop()<cr>", "Quit without saving session" },
   }
 ```
 


### PR DESCRIPTION
Was changed the way on how is implemented keybinding and save session execution, in order to follow Persistence plugin's [installation process](https://github.com/folke/persistence.nvim#-installation).

Also was modified custom names on mappings from '+Quit' to '**Session**' in order to make it more clear the action.

Was modified the key mappings to match his action:
- **c**: Restore last session for **CURRENT** dir.
- **l**: Restore **LAST** session.
- **Q**: **QUIT** without saving session.