### PR TITLE
Adds vim-wakatime to extra plugins

### DIFF
--- a/docs/plugins/03-extra-plugins.md
+++ b/docs/plugins/03-extra-plugins.md
@@ -749,6 +749,18 @@ Also define keybindings in your `config.lua`
 },
 ```
 
+### [vim-wakatime](https://github.com/wakatime/vim-wakatime)
+
+**metrics, insights, and time tracking automatically generated from your programming activity**
+
+```lua
+{
+  "wakatime/vim-wakatime"
+}
+```
+
+Once installed and synced, add your WakaTime API Key via `:WakaTimeApiKey` command
+
 ## Language specific
 
 ### [bracey](https://github.com/turbio/bracey.vim)


### PR DESCRIPTION
Was added the installation of [vim-wakatime](https://github.com/wakatime/vim-wakatime) and also a tiny guide to sync a user with the WakaTime API, as is explained in [Configuring section](https://github.com/wakatime/vim-wakatime#configuring) of the plugin.