### PR TITLE
Fix instructions for installing the rolling branch

### DIFF
--- a/docs/01-installing.md
+++ b/docs/01-installing.md
@@ -23,7 +23,7 @@ bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/
 All the new features with all the new bugs:
 
 ```bash
-LVBRANCH=rolling bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/rolling/utils/installer/install.sh)
+LV_BRANCH=rolling bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/rolling/utils/installer/install.sh)
 ```
 
 ```bash


### PR DESCRIPTION
It was installing the master branch because `LVBRANCH` was being passed
in but the install script uses `$LV_BRANCH`.