### PR TITLE
Update scala.md

### DIFF
--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -23,7 +23,7 @@ lvim.plugins = {
     {
       "scalameta/nvim-metals",
       config = function()
-        local metals_config = require("metals").bare_config
+        local metals_config = require("metals").bare_config()
         metals_config.on_attach = function()
           require("lsp").common_on_attach()
         end


### PR DESCRIPTION
Metals doesn't start correctly unless base_config is called as function as in their minimum config example: https://github.com/scalameta/nvim-metals/discussions/39