### PR TITLE
Create lua.md

### DIFF
--- a/docs/languages/lua.md
+++ b/docs/languages/lua.md
@@ -8,7 +8,9 @@
 
 ## Install Language Server
 
-(TODO)
+```vim
+:LspInstall sumneko_lua
+```
 
 ## Formatters
 


### PR DESCRIPTION
I think we should add a Lua section to the languages for consistency. I am not sure if lua is preinstalled on lunarvim, but in that case I think that should be clearly stated on luas language page. Something like "Lua comes preinstalled with lunarvim, so there is no need to download any servers or plugins".