### PR TITLE
fix: change clangd to cpp

### DIFF
--- a/docs/languages/c_cpp.md
+++ b/docs/languages/c_cpp.md
@@ -15,7 +15,7 @@
 You can install `clangd` language server using the [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer)
 
 ```vim
-:LspInstall clangd
+:LspInstall cpp
 ```
 
 Check the official documentation for other methods <https://clangd.llvm.org/installation>.


### PR DESCRIPTION
Hello, so I'm not sure if this was just a problem on my side or not, but I was not able to install clangd using `:LspInstall clangd` however I was able to install it using `:LspInstall cpp` figured I would make this PR just in case.