### PR TITLE
Add additional debug information for the Go language

### DIFF
--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -32,8 +32,61 @@ Configure `json` to use auto-completion
 :DIInstall go_delve
 ```
 
+Using delve directly:
+
 ```lua
 -- ~/.config/lvim/ftplugin/go.lua
 local dap_install = require "dap-install"
 dap_install.config("go_delve", {})
+```
+
+Using the [vscode-go debug adapter](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#go):
+
+```lua
+local dap = require "dap"
+dap.adapters.go = {
+  type = 'executable';
+  command = 'node';
+  args = {os.getenv('HOME') .. '/vscode-go/dist/debugAdapter.js'}; -- specify the path to the adapter
+}
+dap.configurations.go = {
+  {
+    type = "go",
+    name = "Attach",
+    request = "attach",
+    processId = require("dap.utils").pick_process,
+    program = "${workspaceFolder}",
+    dlvToolPath = vim.fn.exepath('dlv')
+  },
+  {
+    type = "go",
+    name = "Debug curr file",
+    request = "launch",
+    program = "${file}",
+    dlvToolPath = vim.fn.exepath('dlv')
+  },
+  {
+    type = "go",
+    name = "Debug",
+    request = "launch",
+    program = "${workspaceFolder}",
+    dlvToolPath = vim.fn.exepath('dlv')
+  },
+  {
+    type = "go",
+    name = "Debug curr test",
+    request = "launch",
+    mode = "test",
+    program = "${file}",
+    dlvToolPath = vim.fn.exepath('dlv')
+  },
+  {
+    type = "go",
+    name = "Debug test",
+    request = "launch",
+    mode = "test",
+    program = "${workspaceFolder}",
+    dlvToolPath = vim.fn.exepath('dlv')
+  },
+}
 ```


### PR DESCRIPTION
Hi there!

The way  DAPInstall configures [dap for the Go language](https://github.com/Pocco81/DAPInstall.nvim/blob/main/lua/dap-install/core/debuggers/go_delve.lua) , it's by using [this configuration](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#go-using-delve-directly) from the `nvim-dap` package. As stated in the same paragraph (from the last link), this is an `experimental` way from delve to implement the `DAP` protocol directly. I've been playing around with it and it's consistently throwing errors. 

I propose to let know folks the stable way of debugging Go code by using the vs-code debugging adapter, while the other implementation gets stable enough so we can recommend it.

Thanks for this amazing configuration! 
