### PR TITLE
feat: add docs for QML

### DIFF
--- a/docs/languages/qml.md
+++ b/docs/languages/qml.md
@@ -1,0 +1,35 @@
+# QML
+
+## Install Syntax Highlighting
+
+There is no official Treesitter support for QML, so instead you could use [the
+plugin](https://github.com/peterhoeg/vim-qml):
+
+```lua
+{
+  "peterhoeg/vim-qml",
+  event = "BufRead",
+  ft = { "qml" },
+},
+```
+
+## Supported language servers
+
+Currently QML does not have an official LSP, but its development is currently
+[in progress](https://bugreports.qt.io/browse/QTBUG-68406).
+
+## Supported formatters
+
+```lua
+qml = { "qmlformat" }
+```
+
+## Supported linters
+
+```lua
+qml = { "qmllint" }
+```
+
+## See also
+
+- [C/C++ Configuration](c_cpp.md)


### PR DESCRIPTION
null-ls [recently added support](https://github.com/jose-elias-alvarez/null-ls.nvim/pull/304) for a couple of QML tools, so I thought it is worth to add a list here.