### PR TITLE
fix: fixed screen flashing on initial load when using dark mode

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -62,6 +62,8 @@ module.exports = {
       "/sponsors/": getSideBar("sponsors", "Sponsors", true),
     },
   },
+  templateDev: path.join(__dirname, 'templates', 'index.dev.html'),
+  templateSSR: path.join(__dirname, 'templates', 'index.ssr.html'),
 };
 
 function getSideBar(folder, title, include_readme) {

--- a/docs/.vuepress/templates/index.dev.html
+++ b/docs/.vuepress/templates/index.dev.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <style>
+    :root {
+      --c-bg: #fff;
+    }
+
+    html.dark {
+      --c-bg: #22272e;
+    }
+
+    html,
+    body {
+      background-color: var(--c-bg);
+    }
+  </style>
+  <script>
+    (function () {
+      const userMode = localStorage.getItem('vuepress-color-scheme');
+      const systemDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+      if (userMode === 'dark' || (userMode !== 'light' && systemDarkMode)) {
+        document.documentElement.classList.toggle('dark', true);
+      }
+    })();
+  </script>
+</head>
+
+<body>
+  <div id="app"></div>
+</body>
+
+</html>

--- a/docs/.vuepress/templates/index.ssr.html
+++ b/docs/.vuepress/templates/index.ssr.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+
+<head>
+  <style>
+    :root {
+      --c-bg: #fff;
+    }
+
+    html.dark {
+      --c-bg: #22272e;
+    }
+
+    html,
+    body {
+      background-color: var(--c-bg);
+    }
+  </style>
+  <script>
+    (function () {
+      const userMode = localStorage.getItem('vuepress-color-scheme');
+      const systemDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+      if (userMode === 'dark' || (userMode !== 'light' && systemDarkMode)) {
+        document.documentElement.classList.toggle('dark', true);
+      }
+    })();
+  </script>
+  <!--vuepress-ssr-head-->
+  <!--vuepress-ssr-resources-->
+  <!--vuepress-ssr-styles-->
+</head>
+
+<body>
+  <div id="app">
+    <!--vuepress-ssr-app-->
+  </div>
+  <!--vuepress-ssr-scripts-->
+</body>
+
+</html>


### PR DESCRIPTION
screen would flash from what seems like a background transition
in the default CSS of Vuepress

index.dev and index.ssr html files added in .vuepress/templates that
are used to remove the default CSS that causes this behavior on
initial load

Solution found in this discussion [here](https://issueexplorer.com/issue/vuepress/vuepress-next/387)