### PR TITLE
Update lsp installer link and name

### DIFF
--- a/docs/plugins/02-default-plugins.md
+++ b/docs/plugins/02-default-plugins.md
@@ -25,7 +25,7 @@ Automatically launch and initialize language servers
 | ---------- | --------------------------- |
 | `:LspInfo` | Language server diagnostics |
 
-**[nvim-lspinstall](https://github.com/kabouzeid/nvim-lspinstall): Companion plugin for nvim-lspconfig to install language servers**
+**[nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer): Companion plugin for nvim-lspconfig to install language servers**
 
 Use tab completion with LspInstall to check for available language servers
 


### PR DESCRIPTION
The documentation was still pointing to the now deprecated `nvim-lspinstall` plugin, but the actual plugin installed is `nvim-lsp-installer`. This updates the name in the documentation, as well as the link.