### PR TITLE
chore: remove duplications in /languages/javascript page

### DIFF
--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -43,15 +43,3 @@ The configured linter(s) must be installed separately.
 ```lua
 javascript = { "denols", "ember", "eslint", "eslintls", "rome", "stylelint_lsp", "tailwindcss", "tsserver" }
 ```
-
-## Supported formatters
-
-```lua
-javascript = { "deno", "eslint", "eslint_d", "prettier", "prettier_d_slim", "prettierd", "rustywind" }
-```
-
-## Supported linters
-
-```lua
-javascript = { "eslint", "eslint_d" }
-```


### PR DESCRIPTION
i noticed that `## Supported formatters` and `## Supported linters` sections have duplications at the end of page which they have the same content. so i proposed this change to remove one of them.

(LunarVim is very good! thanks for your awesome works 👍)