### PR TITLE
Update documentation about null-ls settings

### DIFF
--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -163,13 +163,46 @@ linters.setup {
     filetypes = { "javascript", "python" },
   },
 }
+
+local code_actions = require "lvim.lsp.null-ls.code_actions"
+code_actions.setup {
+  {
+    command = "proselint"
+  },
+}
 ```
 
-_Note: Formatters' or Linters' installation is not managed by LunarVim. Refer to the each tool's respective manual for installation steps._
+Another method is to reference the linter/formatter/code_actions by their names, as referenced in [null-ls docs](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md), if you do not want to customize the command
+
+```lua
+local formatters = require "lvim.lsp.null-ls.formatters"
+formatters.setup {
+  { name = "black" },
+}
+
+local linters = require "lvim.lsp.null-ls.linters"
+linters.setup {
+  { name = "flake8" },
+  { name = "shellcheck" },
+  {
+    name = "codespell",
+    filetypes = { "javascript", "python" },
+  },
+}
+
+local code_actions = require "lvim.lsp.null-ls.code_actions"
+code_actions.setup {
+  {
+    name = "proselint"
+  },
+}
+```
+
+_Note: Formatters' or Linters' or Code Actions installation is not managed by LunarVim. Refer to the each tool's respective manual for installation steps._
 
 ### Custom arguments
 
-It's also possible to add custom arguments for each formatter.
+It's also possible to add custom arguments for each linter/formatter/code_actions.
 
 ```lua
 local formatters = require "lvim.lsp.null-ls.formatters"
@@ -189,6 +222,14 @@ linters.setup {
     ---@usage arguments to pass to the formatter
     -- these cannot contain whitespaces, options such as `--line-width 80` become either `{'--line-width', '80'}` or `{'--line-width=80'}`
     args = { "--severity", "warning" },
+  },
+}
+
+local code_actions = require "lvim.lsp.null-ls.code_actions"
+code_actions.setup {
+  {
+    command = "proselint",
+    args = { "--json" },
   },
 }
 ```
@@ -212,7 +253,7 @@ formatters.setup {
 
 _Note: removing the `filetypes` argument will allow the formatter to attach to all the default filetypes it supports._
 
-### Multi linters/formatters per language
+### Multi linters/formatters/code_actions per language
 
 There are no restrictions on setting up multiple formatters per language
 
@@ -231,6 +272,15 @@ linters.setup {
     command = "codespell",
     ---@usage specify which filetypes to enable. By default a providers will attach to all the filetypes it supports.
     filetypes = { "javascript", "python" },
+  },
+}
+
+local code_actions = require "lvim.lsp.null-ls.code_actions"
+code_actions.setup {
+  {
+    command = "proselint",
+    args = { "--json" },
+    filetypes = { "markdown", "tex" },
   },
 }
 ```

--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -91,6 +91,7 @@ A typical setup call with default arguments
 -- edit this file by running `:lua vim.cmd("edit " .. lvim.lsp.templates_dir .. "/lua.lua"))`
 require("lvim.lsp.manager").setup("sumneko_lua")
 ```
+
 ::: tip
 You can quickly find these files by running `<leader>Lf` -> "Find LunarVim Files"
 :::
@@ -142,9 +143,9 @@ Set a formatter, this will override the language server formatting capabilities 
 ```lua
 local formatters = require "lvim.lsp.null-ls.formatters"
 formatters.setup {
-  { exe = "black" },
+  { command = "black" },
   {
-    exe = "prettier",
+    command = "prettier",
     args = { "--print-width", "100" },
     filetypes = { "typescript", "typescriptreact" },
   },
@@ -161,7 +162,7 @@ It's also possible to add custom arguments for each formatter.
 local formatters = require "lvim.lsp.null-ls.formatters"
 formatters.setup {
   {
-    exe = "prettier",
+    command = "prettier",
     ---@usage arguments to pass to the formatter
     -- these cannot contain whitespaces, options such as `--line-width 80` become either `{'--line-width', '80'}` or `{'--line-width=80'}`
     args = { "--print-width", "100" },
@@ -179,7 +180,7 @@ By default a formatter will attach to all the filetypes it supports.
 local formatters = require "lvim.lsp.null-ls.formatters"
 formatters.setup {
   {
-    exe = "prettier",
+    command = "prettier",
     ---@usage specify which filetypes to enable. By default a providers will attach to all the filetypes it supports.
     filetypes = { "typescript", "typescriptreact" },
   },
@@ -196,8 +197,8 @@ There are no restrictions on setting up multiple formatters per language
 local formatters = require "lvim.lsp.null-ls.formatters"
 formatters.setup {
   {
-  { exe = "black", filetypes = { "python" } },
-  { exe = "isort", filetypes = { "python" } },
+  { command = "black", filetypes = { "python" } },
+  { command = "isort", filetypes = { "python" } },
   },
 }
 ```
@@ -214,7 +215,7 @@ Let's take `markdown` as an example:
 
 ```lua
 local formatters = require "lvim.lsp.null-ls.formatters"
-formatters.setup({{exe = "prettier", filetypes = {"markdown"} }})
+formatters.setup({{command = "prettier", filetypes = {"markdown"} }})
 ```
 
 ### Formatting on save
@@ -234,13 +235,13 @@ Set additional linters
 ```lua
 local linters = require "lvim.lsp.null-ls.linters"
 linters.setup {
-  { exe = "flake8" },
+  { command = "flake8" },
   {
-    exe = "shellcheck",
+    command = "shellcheck",
     args = { "--severity", "warning" },
   },
   {
-    exe = "codespell",
+    command = "codespell",
     filetypes = { "javascript", "python" },
   },
 }
@@ -256,7 +257,7 @@ It's also possible to add custom arguments for each linter.
 local linters = require "lvim.lsp.null-ls.linters"
 linters.setup {
   {
-    exe = "shellcheck",
+    command = "shellcheck",
     ---@usage arguments to pass to the formatter
     -- these cannot contain whitespaces, options such as `--line-width 80` become either `{'--line-width', '80'}` or `{'--line-width=80'}`
     args = { "--severity", "warning" },
@@ -271,8 +272,8 @@ _Note: remember that arguments cannot contains spaces, options such as `--line-w
 ```lua
 local linters = require "lvim.lsp.null-ls.linters"
 linters.setup {
-  { exe = "flake8", filetypes = { "python" } },
-  { exe = "codespell", filetypes = { "python" } },
+  { command = "flake8", filetypes = { "python" } },
+  { command = "codespell", filetypes = { "python" } },
 }
 ```
 
@@ -282,12 +283,13 @@ linters.setup {
 local linters = require "lvim.lsp.null-ls.linters"
 linters.setup {
   {
-    exe = "codespell",
+    command = "codespell",
     ---@usage specify which filetypes to enable. By default a providers will attach to all the filetypes it supports.
     filetypes = { "javascript", "python" },
   },
 }
 ```
+
 ::: tip
 Removing the `filetypes` argument will allow the linter to attach to all the default filetypes it supports.
 :::
@@ -304,5 +306,5 @@ Let's take `python` as an example:
 
 ```lua
 local linters = require "lvim.lsp.null-ls.linters"
-linters.setup({{exe = "flake8", filetypes = { "python" } }})
+linters.setup({{command = "flake8", filetypes = { "python" } }})
 ```

--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -285,20 +285,17 @@ code_actions.setup {
 }
 ```
 
-### Lazy-loading the formatter setup
+### Lazy-loading the linter/formatter/code_actions setup
 
 By default, all null-ls providers are checked on startup. If you want to avoid that or want to only set up the provider when you opening the associated file-type,
 then you can use [filetype plugins](../configuration/07-ftplugin.md) for this purpose.
 
-Let's take `markdown` as an example:
+Let's take `python` as an example:
 
-1. create a file called `markdown.lua` in the `$LUNARVIM_CONFIG_DIR/after/ftplugin` folder
+1. create a file called `python.lua` in the `$LUNARVIM_CONFIG_DIR/after/ftplugin` folder
 2. add the following snippet
 
 ```lua
-local formatters = require "lvim.lsp.null-ls.formatters"
-formatters.setup({{command = "prettier", filetypes = {"markdown"} }})S
-
 local linters = require "lvim.lsp.null-ls.linters"
 linters.setup({{command = "flake8", filetypes = { "python" } }})
 ```

--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -136,9 +136,9 @@ This will create a file in `$LUNARVIM_CONFIG_DIR/lsp-settings`, to enable persis
 Make sure to install `jsonls` for autocompletion.
 :::
 
-## Formatting
+## Linting/Formatting
 
-Set a formatter, this will override the language server formatting capabilities (if it exists)
+Set a linter/formatter, this will override the language server formatting capabilities (if it exists)
 
 ```lua
 local formatters = require "lvim.lsp.null-ls.formatters"
@@ -150,9 +150,22 @@ formatters.setup {
     filetypes = { "typescript", "typescriptreact" },
   },
 }
+
+local linters = require "lvim.lsp.null-ls.linters"
+linters.setup {
+  { command = "flake8" },
+  {
+    command = "shellcheck",
+    args = { "--severity", "warning" },
+  },
+  {
+    command = "codespell",
+    filetypes = { "javascript", "python" },
+  },
+}
 ```
 
-_Note: Formatters' installation is not managed by LunarVim. Refer to the each tool's respective manual for installation steps._
+_Note: Formatters' or Linters' installation is not managed by LunarVim. Refer to the each tool's respective manual for installation steps._
 
 ### Custom arguments
 
@@ -168,11 +181,21 @@ formatters.setup {
     args = { "--print-width", "100" },
   },
 }
+
+local linters = require "lvim.lsp.null-ls.linters"
+linters.setup {
+  {
+    command = "shellcheck",
+    ---@usage arguments to pass to the formatter
+    -- these cannot contain whitespaces, options such as `--line-width 80` become either `{'--line-width', '80'}` or `{'--line-width=80'}`
+    args = { "--severity", "warning" },
+  },
+}
 ```
 
 _Note: remember that arguments cannot contains spaces, options such as `--line-width 80` become either `{'--line-width', '80'}` or `{'--line-width=80'}`._
 
-### Multi languages per formatter
+### Multi languages per linter/formatter
 
 By default a formatter will attach to all the filetypes it supports.
 
@@ -189,7 +212,7 @@ formatters.setup {
 
 _Note: removing the `filetypes` argument will allow the formatter to attach to all the default filetypes it supports._
 
-### Multi formatters per language
+### Multi linters/formatters per language
 
 There are no restrictions on setting up multiple formatters per language
 
@@ -199,6 +222,15 @@ formatters.setup {
   {
   { command = "black", filetypes = { "python" } },
   { command = "isort", filetypes = { "python" } },
+  },
+}
+
+local linters = require "lvim.lsp.null-ls.linters"
+linters.setup {
+  {
+    command = "codespell",
+    ---@usage specify which filetypes to enable. By default a providers will attach to all the filetypes it supports.
+    filetypes = { "javascript", "python" },
   },
 }
 ```
@@ -215,7 +247,10 @@ Let's take `markdown` as an example:
 
 ```lua
 local formatters = require "lvim.lsp.null-ls.formatters"
-formatters.setup({{command = "prettier", filetypes = {"markdown"} }})
+formatters.setup({{command = "prettier", filetypes = {"markdown"} }})S
+
+local linters = require "lvim.lsp.null-ls.linters"
+linters.setup({{command = "flake8", filetypes = { "python" } }})
 ```
 
 ### Formatting on save
@@ -226,85 +261,4 @@ You can disable auto-command and is to true by default.
 
 ```lua
 lvim.format_on_save = true
-```
-
-## Linting
-
-Set additional linters
-
-```lua
-local linters = require "lvim.lsp.null-ls.linters"
-linters.setup {
-  { command = "flake8" },
-  {
-    command = "shellcheck",
-    args = { "--severity", "warning" },
-  },
-  {
-    command = "codespell",
-    filetypes = { "javascript", "python" },
-  },
-}
-```
-
-_Note: linters' installation is not managed by LunarVim. Refer to the each tool's respective manual for installation steps._
-
-### Custom arguments
-
-It's also possible to add custom arguments for each linter.
-
-```lua
-local linters = require "lvim.lsp.null-ls.linters"
-linters.setup {
-  {
-    command = "shellcheck",
-    ---@usage arguments to pass to the formatter
-    -- these cannot contain whitespaces, options such as `--line-width 80` become either `{'--line-width', '80'}` or `{'--line-width=80'}`
-    args = { "--severity", "warning" },
-  },
-}
-```
-
-_Note: remember that arguments cannot contains spaces, options such as `--line-width 80` become either `{'--line-width', '80'}` or `{'--line-width=80'}`._
-
-### Multi linters per language
-
-```lua
-local linters = require "lvim.lsp.null-ls.linters"
-linters.setup {
-  { command = "flake8", filetypes = { "python" } },
-  { command = "codespell", filetypes = { "python" } },
-}
-```
-
-### Multi languages per linter
-
-```lua
-local linters = require "lvim.lsp.null-ls.linters"
-linters.setup {
-  {
-    command = "codespell",
-    ---@usage specify which filetypes to enable. By default a providers will attach to all the filetypes it supports.
-    filetypes = { "javascript", "python" },
-  },
-}
-```
-
-::: tip
-Removing the `filetypes` argument will allow the linter to attach to all the default filetypes it supports.
-:::
-
-### Lazy-loading the linter setup
-
-By default, all null-ls providers are checked on startup. If you want to avoid that or want to only set up the provider when you opening the associated file-type,
-then you can use [filetype plugins](../configuration/07-ftplugin.md) for this purpose.
-
-Let's take `python` as an example:
-
-1. create a file called `python.lua` in the `$LUNARVIM_CONFIG_DIR/after/ftplugin` folder
-2. add the following snippet
-
-```lua
-local linters = require "lvim.lsp.null-ls.linters"
-linters.setup({{command = "flake8", filetypes = { "python" } }})
 ```


### PR DESCRIPTION
Some major changes:
1. Use `command` instead of `exe`, as it has been the de facto way to set up in null-ls documentation
2. Show how to register code-actions
3. Show how to register linter/formatter/code-actions using name, not command 
4. Unify the configuration documentation under one heading level