### PR TITLE
Add make prequisite

### DIFF
--- a/docs/01-installing.md
+++ b/docs/01-installing.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Make sure you have installed the latest version of [`Neovim v0.7.0+`](https://github.com/neovim/neovim/releases/latest).
-- Have `git`, `pip`, `npm`, `node` and `cargo` installed on your system.
+- Have `git`, `gnumake`, `pip`, `npm`, `node` and `cargo` installed on your system.
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 
 # Install

--- a/docs/01-installing.md
+++ b/docs/01-installing.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Make sure you have installed the latest version of [`Neovim v0.7.0+`](https://github.com/neovim/neovim/releases/latest).
-- Have `git`, `gnumake`, `pip`, `npm`, `node` and `cargo` installed on your system.
+- Have `git`, `make`, `pip`, `npm`, `node` and `cargo` installed on your system.
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 
 # Install


### PR DESCRIPTION
I encountered this error while installing.
Solved it by installing `gnumake`.

```
Cloning LunarVim configuration
Cloning into '/home/miki/.local/share/lunarvim/lvim'...
remote: Enumerating objects: 150, done.
remote: Counting objects: 100% (150/150), done.
remote: Compressing objects: 100% (139/139), done.
remote: Total 150 (delta 5), reused 67 (delta 4), pack-reused 0
Receiving objects: 100% (150/150), 117.67 KiB | 3.27 MiB/s, done.
Resolving deltas: 100% (5/5), done.
--------------------------------------------------------------------------------
Installing LunarVim shim
/dev/fd/63: line 388: make: command not found
```