### PR TITLE
Update proposed keybindings for new autocommand syntax

### DIFF
--- a/docs/drafts/keybindgs.md
+++ b/docs/drafts/keybindgs.md
@@ -3,17 +3,21 @@
 ## Python
 
 ```lua
-lvim.autocommands.custom_groups = {
+lvim.autocommands = {
   {
     "Filetype",
-    "python",
-    "nnoremap <leader>r <cmd>lua require('core.terminal')._exec_toggle('python " .. vim.fn.expand "%" .. ";read')<CR>",
+    {
+      pattern = "python",
+      command = "nnoremap <leader>r <cmd>lua require('toggleterm.terminal').Terminal:new {cmd='python ' .. vim.fn.expand('%') .. ';read', hidden =false}:toggle()<CR>",
+    },
   },
   {
     "Filetype",
-    "python",
-    "nnoremap <leader>t <cmd>lua require('toggleterm.terminal').Terminal:new {cmd='python -m unittest;read', hidden =false}:toggle()<CR>",
-  },
+    {
+      pattern = "python",
+      command = "nnoremap <leader>t <cmd>lua require('toggleterm.terminal').Terminal:new {cmd='python -m unittest;read', hidden =false}:toggle()<CR>",
+    },
+  }
 }
 lvim.builtin.which_key.mappings["r"] = "Run"
 lvim.builtin.which_key.mappings["t"] = "Test"


### PR DESCRIPTION
Hey, 
based on https://github.com/LunarVim/LunarVim/pull/2592 I updated the proposed syntax for the autocommands.

Also, before this was using `require('core.terminal')`. I changed that to use toggleterm b/c the other function was not working for me.

I'm new to lua and had to fight a bit with the string concatenation. For me, this works but maybe s.o. should check 😃 .