### PR TITLE
fix(lsp_signature): Correct setup instructions

### DIFF
--- a/docs/plugins/02-extra-plugins.md
+++ b/docs/plugins/02-extra-plugins.md
@@ -497,10 +497,8 @@ end
 ```lua
 {
   "ray-x/lsp_signature.nvim",
-  event = "BufRead",
-  config = function()
-    require "lsp_signature".setup()
-  end
+  event = "BufRead"
+  config = function() require"lsp_signature".on_attach() end,
 }
 ```
 


### PR DESCRIPTION
Update the docs to match current project [README](https://github.com/LunarVim/LunarVim/blob/rolling/README.md?plain=1#L122) (which works).
Docs always list `event` key first, README doesn't. :)
