### PR TITLE
Fix instructions to add plugin simrat39/symbols-outline.nvim.

### DIFF
--- a/docs/plugins/02-extra-plugins.md
+++ b/docs/plugins/02-extra-plugins.md
@@ -562,7 +562,9 @@ end
 ```lua
 {
   "simrat39/symbols-outline.nvim",
-  cmd = "SymbolsOutline",
+  config = function()
+    require('symbols-outline').setup()
+  end
 },
 ```
 


### PR DESCRIPTION
This fixes the documentation example for adding plugin simrat39/symbols-outline.nvim.

The method described in the documentation fails with a lua fatal error. A related problem is described in the plugin repo as [issue #156](https://github.com/simrat39/symbols-outline.nvim/issues/156#issuecomment-1222192595).

The fix is directly based in [this comment in the issue thread](https://github.com/simrat39/symbols-outline.nvim/issues/156#issuecomment-1222192595).

I tested the fix and it solves the problem. IMHO the documentation needs to be updated accordingly.