### PR TITLE
Fix typo in languages/README.md

### DIFF
--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-LunarVim strives to have support for all major languages. This is made possible by utilizing some of the great plugins in Neovim's ecosystem. Such plugins are [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), for LSP support, and [Null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) to provide support for handling external formatters, such as [prettier](https://github.com/prettier/prettier) and [eslint](https://github.com/eslint/eslint). Furthermore, LunarVim integrates with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) to provider rich syntax highlighting and other language parsing magic.
+LunarVim strives to have support for all major languages. This is made possible by utilizing some of the great plugins in Neovim's ecosystem. Such plugins are [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), for LSP support, and [Null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) to provide support for handling external formatters, such as [prettier](https://github.com/prettier/prettier) and [eslint](https://github.com/eslint/eslint). Furthermore, LunarVim integrates with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) to provide rich syntax highlighting and other language parsing magic.
 
 If your language is not supported please check the following links and file a ticket so we can
 


### PR DESCRIPTION
Fixes a typo, where "to provider" should be "to provide".