### PR TITLE
Update config.lua section

### DIFF
--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -48,9 +48,10 @@ lvim.plugins = {
     },
 }
 
-lvim.autocommands.custom_groups = {
-  { "FileType", "scala,sbt", "lua require('user.metals').config()" }
-}
+vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
+  pattern = { "*.scala", "*.sbt", "*.sc" },
+  callback = function() require('user.metals').config() end,
+})
 ```
 
 ## Supported formatters


### PR DESCRIPTION
`lvim.autocommands.custom_groups` is deprecated as of my installation of the stable version of lvim (23 SEP 2022). In this change, I rewrote the deprecated configuration. 