### PR TITLE
fix: preview images path in different language

### DIFF
--- a/src/components/Preview/index.jsx
+++ b/src/components/Preview/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from "./styles.module.css";
 import Clouds from "../Clouds/";
 
@@ -34,7 +35,7 @@ const Preview = () => {
       <div className={`container ${styles.container}`}>
         <div className={styles.slider}>
           <img
-            src={previewImgs[previewIdx].src}
+            src={useBaseUrl(previewImgs[previewIdx].src)}
             alt={previewImgs[previewIdx].alt}
             loading="lazy"
           />


### PR DESCRIPTION
previously the images weren't loaded form the base path when viewing the site in another language