### PR TITLE
docs: add tutorial to installation and color scheme section

### DIFF
--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -33,7 +33,7 @@ bash <(curl -s https://raw.githubusercontent.com/LunarVim/LunarVim/rolling/utils
 ```
 
 Make sure to check the [troubleshooting](./troubleshooting/README.md) section if you encounter any problem.
-<iframe width="560" height="315" src="https://www.youtube.com/embed/NlRxRtGpHHk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NlRxRtGpHHk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
 
 ## Tips for WSL 2 users
 

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -33,6 +33,7 @@ bash <(curl -s https://raw.githubusercontent.com/LunarVim/LunarVim/rolling/utils
 ```
 
 Make sure to check the [troubleshooting](./troubleshooting/README.md) section if you encounter any problem.
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NlRxRtGpHHk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Tips for WSL 2 users
 

--- a/docs/configuration/03-colorschemes.md
+++ b/docs/configuration/03-colorschemes.md
@@ -41,4 +41,4 @@ cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
 cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
 cmd "let &fcs='eob: '"
 ```
-<iframe width="560" height="315" src="https://www.youtube.com/embed/OOr1qM17Lds" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/OOr1qM17Lds" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>

--- a/docs/configuration/03-colorschemes.md
+++ b/docs/configuration/03-colorschemes.md
@@ -41,4 +41,4 @@ cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
 cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
 cmd "let &fcs='eob: '"
 ```
-
+<iframe width="560" height="315" src="https://www.youtube.com/embed/OOr1qM17Lds" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
Embed the two youtube videos [chris@machine](https://youtu.be/NlRxRtGpHHk) and [chris@machine](https://youtu.be/OOr1qM17Lds) from [chris@machine](https://www.youtube.com/c/ChrisAtMachine) in the docs first is embeded in installation guid and second is embeded in color schemes docs respectively.