### PR TITLE
docs(lsp): update default list of skipped_servers

### DIFF
--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -67,11 +67,7 @@ See the current list
 :lua print(vim.inspect(lvim.lsp.automatic_configuration.skipped_servers))
 ```
 
-See the default list
-
-```lua
-:lua print(vim.inspect(lvim.lsp.automatic_configuration.skipped_servers))
-```
+See the default list in [`lua/lvim/lsp/config.lua`](https://github.com/LunarVim/LunarVim/blob/master/lua/lvim/lsp/config.lua#L1-L40)
 
 :::tip
 


### PR DESCRIPTION
#177 updated the "See the current list" and "See the default list" for `skipped_servers` with [identical content][1]:
> <img width="1122" alt="image" src="https://user-images.githubusercontent.com/12410942/197924956-1203cdbd-3926-4dd9-8549-ea135bbb5481.png">


Since the value of `lvim.lsp.automatic_configuration.skipped_servers` will reflect [our changes in `config.lua`][2], I believe printing `lvim.lsp.automatic_configuration.skipped_servers` is only applicable for "See the default list".

> <img width="1728" alt="image" src="https://user-images.githubusercontent.com/12410942/197318482-382b0878-c382-4f17-a90c-1f29c9912946.png">
> ▲ The output of `:lua print(vim.inspect(lvim.lsp.automatic_configuration.skipped_servers))` reflects our config. Note that `emmet_ls` is missing from the output.

I did not find a way to print the default `local skipped_servers` so I updated "See the default list" to point to the corresponding lines in the source code. I didn't use [its permalink][3] here because IMO when the source code change in the future, linking to the wrong lines is better than linking to the outdated lines.

[1]: https://github.com/LunarVim/lunarvim.org/pull/177/commits/ea31def65ecdba08fd3671d78b65542973a4074f#diff-d78131b67c5f1bd1d134fb5618c3de29ee6a1c6c79a9ce5fe4e271769830e7afR62-R72
[2]: https://github.com/LunarVim/LunarVim/blob/36c8bdee9ff59a0a63c1edfc445b5eb2886cf246/utils/installer/config.example.lua#L109-L119
[3]: https://github.com/LunarVim/LunarVim/blob/36c8bdee9ff59a0a63c1edfc445b5eb2886cf246/lua/lvim/lsp/config.lua#L1-L40