### PR TITLE
fix(scala.md): don't start metals everywhere

### DIFF
--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -45,12 +45,9 @@ Add the following to your `config.lua`
 
 ```lua
 lvim.plugins = {
-    {
-      "scalameta/nvim-metals",
-      config = function()
-        require("user.metals").config()
-      end,
-    },
+  {
+    "scalameta/nvim-metals",
+  },
 }
 
 vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {


### PR DESCRIPTION
config in lvim.plugins caused metals to start in every filetype and create log files in cwd.
Issue in lvim: [link](https://github.com/LunarVim/LunarVim/issues/3340)