### PR TITLE
docs: fixed scala setup and added dap capability in scala

### DIFF
--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -35,7 +35,12 @@ M.config = function()
     excludedPackages = {},
   }
   metals_config.init_options.statusBarProvider = false
-  require("metals").initialize_or_attach { metals_config }
+  require("metals").initialize_or_attach(metals_config)
+  vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
+    pattern = { "*.scala", "*.sbt", "*.sc" },
+    callback = function() require("metals").initialize_or_attach(config) end,
+  })
+  require("metals").setup_dap()
 end
 
 return M
@@ -53,12 +58,32 @@ lvim.plugins = {
     },
 }
 
-vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
-  pattern = { "*.scala", "*.sbt", "*.sc" },
-  callback = function() require('user.metals').config() end,
-})
+dap.configurations.scala = {
+  {
+    type = "scala",
+    request = "launch",
+    name = "Run or Test Target",
+    metals = {
+      runType = "runOrTestFile",
+    },
+  },
+  {
+    type = "scala",
+    request = "launch",
+    name = "Test Target",
+    metals = {
+      runType = "testTarget",
+    },
+  },
+}
 ```
 When you open the first scala file, you should run `:MetalsInstall` in order to complete the plugin installation.
+
+To debug scala program, make sure that dap is activated:
+```
+lvim.builtin.dap.active = true
+```
+Any Lunarvim builtin debug commands, which could be displayed by pressing `<leader> d`, is supported.
 
 ## Supported formatters
 

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -28,16 +28,16 @@ local M = {}
 
 M.config = function()
   local lvim_lsp = require("lvim.lsp")
-  local config = require("metals").bare_config()
-  config.on_init = lvim_lsp.common_on_init
-  config.on_exit = lvim_lsp.common_on_exit
-  config.capabilities = lvim_lsp.common_capabilities()
-  config.on_attach = function(client, bufnr)
+  local metals_config = require("metals").bare_config()
+  metals_config.on_init = lvim_lsp.common_on_init
+  metals_config.on_exit = lvim_lsp.common_on_exit
+  metals_config.capabilities = lvim_lsp.common_capabilities()
+  metals_config.on_attach = function(client, bufnr)
     lvim_lsp.common_on_attach(client, bufnr)
     require("metals").setup_dap()
   end
-  config.init_options.statusBarProvider = false
-  config.settings = {
+  metals_config.init_options.statusBarProvider = false
+  metals_config.settings = {
     superMethodLensesEnabled = true,
     showImplicitArguments = true,
     showInferredType = true,
@@ -46,7 +46,7 @@ M.config = function()
   }
   vim.api.nvim_create_autocmd("FileType", {
     pattern = { "scala", "sbt", "java" },
-    callback = function() require("metals").initialize_or_attach(config) end,
+    callback = function() require("metals").initialize_or_attach(metals_config) end,
     group = vim.api.nvim_create_augroup("nvim-metals", { clear = true }),
   })
 end

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -36,7 +36,6 @@ M.config = function()
     lvim_lsp.common_on_attach(client, bufnr)
     require("metals").setup_dap()
   end
-  metals_config.init_options.statusBarProvider = false
   metals_config.settings = {
     superMethodLensesEnabled = true,
     showImplicitArguments = true,
@@ -44,6 +43,7 @@ M.config = function()
     showImplicitConversionsAndClasses = true,
     excludedPackages = {},
   }
+  metals_config.init_options.statusBarProvider = false
   vim.api.nvim_create_autocmd("FileType", {
     pattern = { "scala", "sbt", "java" },
     callback = function() require("metals").initialize_or_attach(metals_config) end,

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -27,20 +27,28 @@ Create a file called `~/.config/lvim/lua/user/metals.lua`:
 local M = {}
 
 M.config = function()
-  local metals_config = require("metals").bare_config()
-  metals_config.on_attach = require("lvim.lsp").common_on_attach
-  metals_config.settings = {
-    showImplicitArguments = false,
+  local lvim_lsp = require("lvim.lsp")
+  local config = require("metals").bare_config()
+  config.on_init = lvim_lsp.common_on_init
+  config.on_exit = lvim_lsp.common_on_exit
+  config.capabilities = lvim_lsp.common_capabilities()
+  config.on_attach = function(client, bufnr)
+    lvim_lsp.common_on_attach(client, bufnr)
+    require("metals").setup_dap()
+  end
+  config.init_options.statusBarProvider = false
+  config.settings = {
+    superMethodLensesEnabled = true,
+    showImplicitArguments = true,
     showInferredType = true,
+    showImplicitConversionsAndClasses = true,
     excludedPackages = {},
   }
-  metals_config.init_options.statusBarProvider = false
-  require("metals").initialize_or_attach(metals_config)
-  vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
-    pattern = { "*.scala", "*.sbt", "*.sc" },
+  vim.api.nvim_create_autocmd("FileType", {
+    pattern = { "scala", "sbt", "java" },
     callback = function() require("metals").initialize_or_attach(config) end,
+    group = vim.api.nvim_create_augroup("nvim-metals", { clear = true }),
   })
-  require("metals").setup_dap()
 end
 
 return M


### PR DESCRIPTION
Summary of this PR:
- Fix a bug on the previous setup which made the `metals_config.on_attach` callback not called.
- Fixed a bug about metals being initialized every time Lunarvim config is invoked, even though we're not in scala buffers. PS: This is also a current [issue.](https://github.com/LunarVim/LunarVim/issues/3340).
- Added dap capability.