### PR TITLE
docs: update `auto-save.nvim` plugin url

### DIFF
--- a/docs/plugins/02-extra-plugins.md
+++ b/docs/plugins/02-extra-plugins.md
@@ -595,13 +595,13 @@ lvim.builtin.which_key.mappings["t"] = {
 
 ## General
 
-### [autosave](https://github.com/Pocco81/AutoSave.nvim)
+### [auto-save](https://github.com/Pocco81/auto-save.nvim)
 
 **automatically saving your work whenever you make changes to it**
 
 ```lua
 {
-  "Pocco81/AutoSave.nvim",
+  "Pocco81/auto-save.nvim",
   config = function()
     require("autosave").setup()
   end,


### PR DESCRIPTION
Hi :wave:,
according to https://github.com/Pocco81/auto-save.nvim#-disclaimer-breaking-change the name was adjusted from `AutoSave` to `auto-save`.

Therefore this PR adjusts the URL.