### PR TITLE
doc(): fix octo plugin install

### DIFF
--- a/docs/plugins/02-extra-plugins.md
+++ b/docs/plugins/02-extra-plugins.md
@@ -279,7 +279,14 @@ vim.keymap.set('n', ',W', swap_windows, { desc = 'Swap windows' })
 ```lua
 {
   "pwntester/octo.nvim",
-  event = "BufRead",
+  requires = {
+    'nvim-lua/plenary.nvim',
+    'nvim-telescope/telescope.nvim',
+    'kyazdani42/nvim-web-devicons',
+  },
+  config = function()
+    require("octo").setup()
+  end,
 },
 ```
 


### PR DESCRIPTION
Suggested configuration did not work out of the box (at least with my setup).

I simply copy/pasted the [official doc](https://github.com/pwntester/octo.nvim#-installation) to make it work.
