### PR TITLE
Document vim-matchup treesitter integration enabling

### DIFF
--- a/docs/plugins/02-extra-plugins.md
+++ b/docs/plugins/02-extra-plugins.md
@@ -161,6 +161,9 @@ Every plugin that works with Neovim works with LunarVim, here are some examples 
     vim.g.matchup_matchparen_offscreen = { method = "popup" }
   end,
 },
+
+-- enable treesitter integration
+lvim.builtin.treesitter.matchup.enable = true
 ```
 
 ### [nvim-window-picker](https://github.com/s1n7ax/nvim-window-picker)


### PR DESCRIPTION
Inform the user that treesitter can be enabled when using vim-matchup, similar to nvim-ts-rainbow.