### PR TITLE
docs: add links for dependencies on installation page

### DIFF
--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Make sure you have installed the latest version of [`Neovim v0.8.0+`](https://github.com/neovim/neovim/releases/latest).
-- Have `git`, `make`, `pip`, `npm`, `node` and `cargo` installed on your system.
+- Have [`git`](https://cli.github.com/), [`make`](https://cmake.org/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/) [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/) and [`cargo`](https://www.rust-lang.org/tools/install) installed on your system.
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (for Windows)
 


### PR DESCRIPTION
This adds links for the dependencies under the "Prerequisites" category of the [installation page](https://www.lunarvim.org/docs/installation)