### PR TITLE
fix broken links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,10 +56,6 @@ const config = {
               label: 'master',
               path: 'master',
             },
-            '1.2': {
-              label: '1.2',
-              path: '1.2',
-            },
           },
         },
         blog: {


### PR DESCRIPTION
my versioning PR broke links, so the latest build failed, this PR fixes it

moves latest docs to `/docs`
`/docs/1.2` -> `/docs/`