### PR TITLE
docs: add keybind overview

### DIFF
--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -43,5 +43,6 @@ Installing a [nerd font](https://www.nerdfonts.com/) is recommended. Otherwise s
 ## Next Steps
 
 - Learn how to [configure LunarVim](./configuration/README.md)
+- See the [keybind overview](./03-keybind-overview.md)
 - Learn about the [installed plugins](./plugins/README.md)
 - Learn how to set up LunarVim for your [language](./languages/README.md)

--- a/docs/03-keybind-overview.md
+++ b/docs/03-keybind-overview.md
@@ -1,0 +1,82 @@
+# Keybind overview
+
+Here's an overview of the most commonly used mappings.
+It is not a complete list, you can find more by pressing `<leader>sk` to search through them,
+or `<leader>` to show whichkey (keybinds popup)
+
+Also see:
+[vim mappings](https://devhints.io/vim)
+
+**TIP:** `<leader>` is space by default, read `:help keycodes` for more key names
+
+**TIP:** `<M>` is `alt` on Windows/Linux and `option` on MacOS
+
+## Plugins
+
+| key                 | description                                                                              | mode   |
+| ------------------- | ---------------------------------------------------------------------------------------- | ------ |
+| `<leader>`          | [whichkey](https://github.com/folke/which-key.nvim) (keybinds popup (shows up after 1s)) | normal |
+| `<leader>e`         | [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)              | normal |
+| `<leader>f`         | [telesope](https://github.com/nvim-telescope/telescope.nvim) (find files)                | normal |
+| `<leader>;`         | [alpha](https://github.com/goolord/alpha-nvim) (dashboard)                               | normal |
+| `<C-\>` `<M-1/2/3>` | [toggleterm](https://github.com/akinsho/toggleterm.nvim) (terminal)                      | normal |
+
+## LSP
+
+| key  | description           | mode   |
+| ---- | --------------------- | ------ |
+| `K`  | hover information     | normal |
+| `gd` | go to definition      | normal |
+| `gD` | go to declaration     | normal |
+| `gr` | go to references      | normal |
+| `gI` | go to implementation  | normal |
+| `gs` | show signature help   | normal |
+| `gl` | show line diagnostics | normal |
+
+## Editing
+
+| key         | description       | mode           |
+| ----------- | ----------------- | -------------- |
+| `<leader>/` | comment           | normal, visual |
+| `gb`        | block comment     | visual         |
+| `<A-k>`     | move line(s) up   | normal, visual |
+| `<A-j>`     | move line(s) down | normal, visual |
+
+## Completion
+
+| key                        | description                            | mode   |
+| -------------------------- | -------------------------------------- | ------ |
+| `<C-space>`                | show completion menu                   | insert |
+| `<CR>` `<C-y>`             | confirm                                | insert |
+| `<C-e>`                    | abort                                  | insert |
+| `<C-k>` `<Up>` `<Tab>`     | select previous item                   | insert |
+| `<C-j>` `<Down>` `<S-Tab>` | select next item                       | insert |
+| `<C-d>`                    | scroll docs up                         | insert |
+| `<C-f>`                    | scroll docs down                       | insert |
+| `<CR>` `<Tab>`             | jump to next jumpable in a snippet     | insert |
+| `<S-Tab>`                  | jump to previous jumpable in a snippet | insert |
+
+## Windows
+
+| key         | description            | mode   |
+| ----------- | ---------------------- | ------ |
+| `<C-h>`     | go to left window      | normal |
+| `<C-j>`     | go to lower window     | normal |
+| `<C-k>`     | go to upper window     | normal |
+| `<C-l>`     | go to right window     | normal |
+| `<C-Up>`    | decrease window height | normal |
+| `<C-Down>`  | increase window height | normal |
+| `<C-Left>`  | decrease window width  | normal |
+| `<C-Right>` | increase window width  | normal |
+
+## Miscellaneous
+
+| key          | description               | mode   |
+| ------------ | ------------------------- | ------ |
+| `<leader>Lc` | edit config.lua           | normal |
+| `<leader>h`  | clear search highlighting | normal |
+| `<leader>sh` | search through `:help`    | normal |
+
+## [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)
+
+`g?` show keybidings

--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -1,6 +1,7 @@
 # Keybindings
 
 Use `<Leader>Lk` to view the keybindings set by Lunarvim.
+See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
 
 To modify a single Lunarvim keymapping
 
@@ -20,7 +21,7 @@ To remove keymappings set by Lunarvim
 
 ### Listing what is mapped
 
-Use `<Leader>Vk` to view the keybindings set by Lunarvim.
+Use `<Leader>Lk` to view the keybindings set by Lunarvim.
 
 To see if a particular key has already been bound:
 
@@ -67,6 +68,7 @@ lvim.keys.normal_mode['K'] = "<Cmd>echo Okay!<CR>"
 ## Whichkey Bindings
 
 To add or remap keybindings for whichkey use `lvim.builtin.which_key.mappings`
+The leader key is already included in whichkey mappings
 
 ### Single mapping
 

--- a/versioned_docs/version-1.2/02-quick-start.md
+++ b/versioned_docs/version-1.2/02-quick-start.md
@@ -43,5 +43,6 @@ Installing a [nerd font](https://www.nerdfonts.com/) is recommended. Otherwise s
 ## Next Steps
 
 - Learn how to [configure LunarVim](./configuration/README.md)
+- See the [keybind overview](./03-keybind-overview.md)
 - Learn about the [installed plugins](./plugins/README.md)
 - Learn how to set up LunarVim for your [language](./languages/README.md)

--- a/versioned_docs/version-1.2/03-keybind-overview.md
+++ b/versioned_docs/version-1.2/03-keybind-overview.md
@@ -1,0 +1,82 @@
+# Keybind overview
+
+Here's an overview of the most commonly used mappings.
+It is not a complete list, you can find more by pressing `<leader>sk` to search through them,
+or `<leader>` to show whichkey (keybinds popup)
+
+Also see:
+[vim mappings](https://devhints.io/vim)
+
+**TIP:** `<leader>` is space by default, read `:help keycodes` for more key names
+
+**TIP:** `<M>` is `alt` on Windows/Linux and `option` on MacOS
+
+## Plugins
+
+| key                 | description                                                                              | mode   |
+| ------------------- | ---------------------------------------------------------------------------------------- | ------ |
+| `<leader>`          | [whichkey](https://github.com/folke/which-key.nvim) (keybinds popup (shows up after 1s)) | normal |
+| `<leader>e`         | [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)              | normal |
+| `<leader>f`         | [telesope](https://github.com/nvim-telescope/telescope.nvim) (find files)                | normal |
+| `<leader>;`         | [alpha](https://github.com/goolord/alpha-nvim) (dashboard)                               | normal |
+| `<C-\>` `<M-1/2/3>` | [toggleterm](https://github.com/akinsho/toggleterm.nvim) (terminal)                      | normal |
+
+## LSP
+
+| key  | description           | mode   |
+| ---- | --------------------- | ------ |
+| `K`  | hover information     | normal |
+| `gd` | go to definition      | normal |
+| `gD` | go to declaration     | normal |
+| `gr` | go to references      | normal |
+| `gI` | go to implementation  | normal |
+| `gs` | show signature help   | normal |
+| `gl` | show line diagnostics | normal |
+
+## Editing
+
+| key         | description       | mode           |
+| ----------- | ----------------- | -------------- |
+| `<leader>/` | comment           | normal, visual |
+| `gb`        | block comment     | visual         |
+| `<A-k>`     | move line(s) up   | normal, visual |
+| `<A-j>`     | move line(s) down | normal, visual |
+
+## Completion
+
+| key                        | description                            | mode   |
+| -------------------------- | -------------------------------------- | ------ |
+| `<C-space>`                | show completion menu                   | insert |
+| `<CR>` `<C-y>`             | confirm                                | insert |
+| `<C-e>`                    | abort                                  | insert |
+| `<C-k>` `<Up>` `<Tab>`     | select previous item                   | insert |
+| `<C-j>` `<Down>` `<S-Tab>` | select next item                       | insert |
+| `<C-d>`                    | scroll docs up                         | insert |
+| `<C-f>`                    | scroll docs down                       | insert |
+| `<CR>` `<Tab>`             | jump to next jumpable in a snippet     | insert |
+| `<S-Tab>`                  | jump to previous jumpable in a snippet | insert |
+
+## Windows
+
+| key         | description            | mode   |
+| ----------- | ---------------------- | ------ |
+| `<C-h>`     | go to left window      | normal |
+| `<C-j>`     | go to lower window     | normal |
+| `<C-k>`     | go to upper window     | normal |
+| `<C-l>`     | go to right window     | normal |
+| `<C-Up>`    | decrease window height | normal |
+| `<C-Down>`  | increase window height | normal |
+| `<C-Left>`  | decrease window width  | normal |
+| `<C-Right>` | increase window width  | normal |
+
+## Miscellaneous
+
+| key          | description               | mode   |
+| ------------ | ------------------------- | ------ |
+| `<leader>Lc` | edit config.lua           | normal |
+| `<leader>h`  | clear search highlighting | normal |
+| `<leader>sh` | search through `:help`    | normal |
+
+## [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)
+
+`g?` show keybidings

--- a/versioned_docs/version-1.2/configuration/02-keybindings.md
+++ b/versioned_docs/version-1.2/configuration/02-keybindings.md
@@ -1,6 +1,7 @@
 # Keybindings
 
 Use `<Leader>Lk` to view the keybindings set by Lunarvim.
+See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
 
 To modify a single Lunarvim keymapping
 
@@ -20,7 +21,7 @@ To remove keymappings set by Lunarvim
 
 ### Listing what is mapped
 
-Use `<Leader>Vk` to view the keybindings set by Lunarvim.
+Use `<Leader>Lk` to view the keybindings set by Lunarvim.
 
 To see if a particular key has already been bound:
 
@@ -67,6 +68,7 @@ lvim.keys.normal_mode['K'] = "<Cmd>echo Okay!<CR>"
 ## Whichkey Bindings
 
 To add or remap keybindings for whichkey use `lvim.builtin.which_key.mappings`
+The leader key is already included in whichkey mappings
 
 ### Single mapping
 


### PR DESCRIPTION
adds an overview of the most commonly used mappings
fixes #297
