### PR TITLE
docs: changes in keybind-overview and configuration/keybindings

### DIFF
--- a/docs/03-keybind-overview.md
+++ b/docs/03-keybind-overview.md
@@ -11,6 +11,9 @@ Also see:
 
 **TIP:** `<M>` is `alt` on Windows/Linux and `option` on MacOS
 
+**TIP:** Non-leader keybindings (for e.g. `<C-\>`, mentioned below and others) can be viewed
+by pressing `<backspace>` in the which-key main menu (first popup after pressing `<leader>`)
+
 ## Plugins
 
 | key                 | description                                                                              | mode   |
@@ -39,8 +42,8 @@ Also see:
 | ----------- | ----------------- | -------------- |
 | `<leader>/` | comment           | normal, visual |
 | `gb`        | block comment     | visual         |
-| `<A-k>`     | move line(s) up   | normal, visual |
-| `<A-j>`     | move line(s) down | normal, visual |
+| `<M-k>`     | move line(s) up   | normal, visual |
+| `<M-j>`     | move line(s) down | normal, visual |
 
 ## Completion
 
@@ -76,7 +79,9 @@ Also see:
 | `<leader>Lc` | edit config.lua           | normal |
 | `<leader>h`  | clear search highlighting | normal |
 | `<leader>sh` | search through `:help`    | normal |
+| `<leader>sr` | open recent files         | normal |
+| `<leader>pS` | list of installed plugins | normal |
 
 ## [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)
 
-`g?` show keybidings
+`g?` show keybindings

--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -1,5 +1,13 @@
 # Keybindings
 
+## Leader Key
+
+The default leader key is `Space`. This can be changed with the following
+
+```lua
+lvim.leader = "space"
+```
+
 Use `<Leader>Lk` to view the keybindings set by Lunarvim.
 See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
 
@@ -79,6 +87,7 @@ lvim.builtin.which_key.mappings["P"] = {
   "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects"
 }
 ```
+As stated above, the leader key included. So for the above example, the keybinding becomes `<leader>P`
 
 ### Removing a single mapping
 
@@ -87,7 +96,7 @@ Remove a single Whichkey keybind
 lvim.builtin.which_key.mappings['w'] = {}
 ```
 
-Adding a key to a existing submenu.
+Adding a key to an existing menu/submenu.
 
 ```lua
 lvim.builtin.which_key.mappings["tP"] = {
@@ -132,11 +141,3 @@ lvim.builtin.which_key.mappings = {
 }
 ```
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BdoizYjJHis" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
-
-## Leader Key
-
-The default leader key is `Space`. This can be changed with the following
-
-```lua
-lvim.leader = "space"
-```

--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -87,7 +87,7 @@ lvim.builtin.which_key.mappings["P"] = {
   "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects"
 }
 ```
-As stated above, the leader key included. So for the above example, the keybinding becomes `<leader>P`
+As stated above, the leader key is included. So for the above example, the keybinding becomes `<leader>P`
 
 ### Removing a single mapping
 

--- a/versioned_docs/version-1.2/03-keybind-overview.md
+++ b/versioned_docs/version-1.2/03-keybind-overview.md
@@ -11,6 +11,9 @@ Also see:
 
 **TIP:** `<M>` is `alt` on Windows/Linux and `option` on MacOS
 
+**TIP:** Non-leader keybindings (for e.g. `<C-\>`, mentioned below and others) can be viewed
+by pressing `<backspace>` in the which-key main menu (first popup after pressing `<leader>`)
+
 ## Plugins
 
 | key                 | description                                                                              | mode   |
@@ -39,8 +42,8 @@ Also see:
 | ----------- | ----------------- | -------------- |
 | `<leader>/` | comment           | normal, visual |
 | `gb`        | block comment     | visual         |
-| `<A-k>`     | move line(s) up   | normal, visual |
-| `<A-j>`     | move line(s) down | normal, visual |
+| `<M-k>`     | move line(s) up   | normal, visual |
+| `<M-j>`     | move line(s) down | normal, visual |
 
 ## Completion
 
@@ -76,7 +79,9 @@ Also see:
 | `<leader>Lc` | edit config.lua           | normal |
 | `<leader>h`  | clear search highlighting | normal |
 | `<leader>sh` | search through `:help`    | normal |
+| `<leader>sr` | open recent files         | normal |
+| `<leader>pS` | list of installed plugins | normal |
 
 ## [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)
 
-`g?` show keybidings
+`g?` show keybindings

--- a/versioned_docs/version-1.2/configuration/02-keybindings.md
+++ b/versioned_docs/version-1.2/configuration/02-keybindings.md
@@ -1,5 +1,13 @@
 # Keybindings
 
+## Leader Key
+
+The default leader key is `Space`. This can be changed with the following
+
+```lua
+lvim.leader = "space"
+```
+
 Use `<Leader>Lk` to view the keybindings set by Lunarvim.
 See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
 
@@ -79,6 +87,7 @@ lvim.builtin.which_key.mappings["P"] = {
   "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects"
 }
 ```
+As stated above, the leader key is included. So for the above example, the keybinding becomes `<leader>P`
 
 ### Removing a single mapping
 
@@ -87,7 +96,7 @@ Remove a single Whichkey keybind
 lvim.builtin.which_key.mappings['w'] = {}
 ```
 
-Adding a key to a existing submenu.
+Adding a key to an existing menu/submenu.
 
 ```lua
 lvim.builtin.which_key.mappings["tP"] = {
@@ -132,11 +141,3 @@ lvim.builtin.which_key.mappings = {
 }
 ```
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BdoizYjJHis" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
-
-## Leader Key
-
-The default leader key is `Space`. This can be changed with the following
-
-```lua
-lvim.leader = "space"
-```


### PR DESCRIPTION
### Doc: Keybind overview

Added few key examples, statements and fixed spelling

### Doc: Configuration/Keybindings

Leader key information must come first in the doc. User should know which key is to be pressed first.
Other key-bindings come after it. Hence shifted the info at the top.