### PR TITLE
docs: add mini.map to extra plugins

### DIFF
--- a/versioned_docs/version-1.2/plugins/02-extra-plugins.md
+++ b/versioned_docs/version-1.2/plugins/02-extra-plugins.md
@@ -72,45 +72,31 @@ mini.map doesn't automatically open, by design. The follwing makes sure to fix t
 
 ```
 lvim.autocommands = {
-  ...
   {
-    "BufEnter",
+    {"BufEnter", "Filetype"},
     {
-      desc = "Open mini.map and exclude some filtypes",
+      desc = "Open mini.map and exclude some filetypes",
       pattern = { "*" },
       callback = function()
         local exclude_ft = {
-          "",
-          "nofile",
-          "nowrite",
-          "quickfix",
-          "prompt",
-          "terminal",
+          "qf",
+          "NvimTree",
           "toggleterm",
-          "startify",
-          "dashboard",
+          "TelescopePrompt",
           "alpha",
           "netrw",
-          "NvimTree",
-          "packer",
-          "telescope",
-          "lazygit",
-          "bufferline",
         }
 
         local map = require('mini.map')
-        if vim.o.buftype == "" and not vim.tbl_contains(exclude_ft, vim.o.filetype) then
-          map.open()
-        elseif vim.o.buftype == "nofile" and vim.o.filetype == "minimap" then
-          return
-        else
+        if vim.tbl_contains(exclude_ft, vim.o.filetype) then
           vim.b.minimap_disable = true
           map.close()
+        elseif vim.o.buftype == "" then
+          map.open()
         end
       end,
     },
   },
-  ...
 }
 ```
 

--- a/versioned_docs/version-1.2/plugins/02-extra-plugins.md
+++ b/versioned_docs/version-1.2/plugins/02-extra-plugins.md
@@ -31,21 +31,87 @@ Every plugin that works with Neovim works with LunarVim, here are some examples 
 },
 ```
 
-### [minimap](https://github.com/wfxr/minimap.vim)
+### [mini.map](https://github.com/echasnovski/mini.map/)
 
-**blazing fast minimap/scrollbar written in Rust**
+**blazing fast minimap/scrollbar in Lua**
 
 ```lua
 {
-  'wfxr/minimap.vim',
-  run = "cargo install --locked code-minimap",
-  -- cmd = {"Minimap", "MinimapClose", "MinimapToggle", "MinimapRefresh", "MinimapUpdateHighlight"},
-  config = function ()
-    vim.cmd ("let g:minimap_width = 10")
-    vim.cmd ("let g:minimap_auto_start = 1")
-    vim.cmd ("let g:minimap_auto_start_win_enter = 1")
-  end,
+  "echasnovski/mini.map",
+  branch = "stable",
+  config = function()
+    require('mini.map').setup()
+    local map = require('mini.map')
+    map.setup({
+      integrations = {
+        map.gen_integration.builtin_search(),
+        map.gen_integration.diagnostic({
+          error = 'DiagnosticFloatingError',
+          warn  = 'DiagnosticFloatingWarn',
+          info  = 'DiagnosticFloatingInfo',
+          hint  = 'DiagnosticFloatingHint',
+        }),
+      },
+      symbols = {
+        encode = map.gen_encode_symbols.dot('4x2'),
+      },
+      window = {
+        side = 'right',
+        width = 20, -- set to 1 for a pure scrollbar :)
+        winblend = 15,
+        show_integration_count = false,
+      },
+    })
+  end
 },
+```
+
+#### automatically open mini.map and exclude buffers, filetypes
+
+mini.map doesn't automatically open, by design. The follwing makes sure to fix that and excludes buffers/filetypes you don't want it to open:
+
+```
+lvim.autocommands = {
+  ...
+  {
+    "BufEnter",
+    {
+      desc = "Open mini.map and exclude some filtypes",
+      pattern = { "*" },
+      callback = function()
+        local exclude_ft = {
+          "",
+          "nofile",
+          "nowrite",
+          "quickfix",
+          "prompt",
+          "terminal",
+          "toggleterm",
+          "startify",
+          "dashboard",
+          "alpha",
+          "netrw",
+          "NvimTree",
+          "packer",
+          "telescope",
+          "lazygit",
+          "bufferline",
+        }
+
+        local map = require('mini.map')
+        if vim.o.buftype == "" and not vim.tbl_contains(exclude_ft, vim.o.filetype) then
+          map.open()
+        elseif vim.o.buftype == "nofile" and vim.o.filetype == "minimap" then
+          return
+        else
+          vim.b.minimap_disable = true
+          map.close()
+        end
+      end,
+    },
+  },
+  ...
+}
 ```
 
 ### [numb](https://github.com/nacro90/numb.nvim)


### PR DESCRIPTION
I was soooooooo frustrated with minimap, its conflicts, and its bugs, that I seeked for an alternative for days. I finally found a GREAT ONE called mini.map :)

It works ridiculously well, it's extremley fast and lightweight, and it can double as a sidebar too! 100% Lua, no external dependencies (bar gitsigns if one wants to integrate it), and forget about wxfr brittle changes and stitches to make it compatible. it just works!!!

more rationale here: https://github.com/LunarVim/LunarVim/discussions/2838#discussioncomment-4239332