### PR TITLE
Add example for remapping keybindings

### DIFF
--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -1,5 +1,8 @@
 # Keybindings
 
+Use `<Leader>Lk` to view the keybindings set by Lunarvim.
+See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
+
 ## Leader Key
 
 The default leader key is `Space`. This can be changed with the following
@@ -8,29 +11,7 @@ The default leader key is `Space`. This can be changed with the following
 lvim.leader = "space"
 ```
 
-Use `<Leader>Lk` to view the keybindings set by Lunarvim.
-See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
-
-To modify a single Lunarvim keymapping
-
-```lua
-  -- X closes a buffer
-  lvim.keys.normal_mode["<S-x>"] = ":BufferClose<CR>"
-  
-  -- Centers cursor when moving 1/2 page down
-  lvim.keys.normal_mode["<C-d>"] = "<C-d>zz"
-```
-
-To remove keymappings set by Lunarvim
-
-```lua
-  lvim.keys.normal_mode["<C-h>"] = false
-  lvim.keys.normal_mode["<C-j>"] = false
-  lvim.keys.normal_mode["<C-k>"] = false
-  lvim.keys.normal_mode["<C-l>"] = false
-```
-
-### Listing what is mapped
+## Listing what is mapped
 
 Use `<Leader>Lk` to view the keybindings set by Lunarvim.
 
@@ -50,27 +31,48 @@ Or just list every mapping
 :map
 ```
 
-## Explorer Bindings
+## (Re)mapping keys
 
-To view keybindings for the nvimtree plugin. Make sure you're in an nvimtree buffer and type `g?` to toggle the keybindings help
+```lua
+  -- X closes a buffer
+  lvim.keys.normal_mode["<S-x>"] = ":BufferKill<CR>"
+
+  -- Centers cursor when moving 1/2 page down
+  lvim.keys.normal_mode["<C-d>"] = "<C-d>zz"
+```
+
+## Removing default mappings
+
+```lua
+  lvim.keys.normal_mode["<C-h>"] = false
+  lvim.keys.normal_mode["<C-j>"] = false
+  lvim.keys.normal_mode["<C-k>"] = false
+  lvim.keys.normal_mode["<C-l>"] = false
+```
 
 ## LSP Bindings
 
 To modify your LSP keybindings use `lvim.lsp.buffer_mappings.[normal|visual|insert]_mode`.
 
 ### (Re)map a key
+
 Map your own functionality
+
 ```lua
 lvim.lsp.buffer_mappings.normal_mode['H'] = { vim.lsp.buf.hover, "Show documentation" }
 ```
+
 Or map default functionality to a different key
+
 ```lua
 lvim.lsp.buffer_mappings.normal_mode['gk'] = lvim.lsp.buffer_mappings.normal_mode['K']
 ```
 
 ### Remove a binding
+
 LSP bindings take precedence over regular keybindings. So in order to use a key for a regular binding, we have to remove
 it first
+
 ```lua
 lvim.lsp.buffer_mappings.normal_mode['K'] = nil
 lvim.keys.normal_mode['K'] = "<Cmd>echo Okay!<CR>"
@@ -90,11 +92,13 @@ lvim.builtin.which_key.mappings["P"] = {
   "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects"
 }
 ```
+
 As stated above, the leader key is included. So for the above example, the keybinding becomes `<leader>P`
 
 ### Removing a single mapping
 
 Remove a single Whichkey keybind
+
 ```lua
 lvim.builtin.which_key.mappings['w'] = {}
 ```
@@ -130,17 +134,18 @@ To clear all whichkey bindings and replace all mappings with your own, use this 
 ```lua
 lvim.builtin.which_key.mappings = {
   ["c"] = { "<cmd>BufferClose!<CR>", "Close Buffer" },
-  ["e"] = { "<cmd>lua require'core.nvimtree'.toggle_tree()<CR>", "Explorer" },
+  ["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" },
   ["h"] = { '<cmd>let @/=""<CR>', "No Highlight" },
 
   p = {
     name = "Packer",
     c = { "<cmd>PackerCompile<cr>", "Compile" },
     i = { "<cmd>PackerInstall<cr>", "Install" },
-    r = { "<cmd>lua require('lv-utils').reload_lv_config()<cr>", "Reload" },
+    r = { "<cmd>LvimReload<cr>", "Reload" },
     s = { "<cmd>PackerSync<cr>", "Sync" },
     u = { "<cmd>PackerUpdate<cr>", "Update" },
   },
 }
 ```
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BdoizYjJHis" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>

--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -1,7 +1,6 @@
 # Keybindings
 
-Use `<Leader>Lk` to view the keybindings set by Lunarvim.
-See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
+See the [keybind overview](../03-keybind-overview.md) for most commonly used keybinds
 
 ## Leader Key
 
@@ -33,6 +32,8 @@ Or just list every mapping
 
 ## (Re)mapping keys
 
+To modify or add a keymapping:
+
 ```lua
   -- X closes a buffer
   lvim.keys.normal_mode["<S-x>"] = ":BufferKill<CR>"
@@ -42,6 +43,8 @@ Or just list every mapping
 ```
 
 ## Removing default mappings
+
+To remove keymappings set by Lunarvim:
 
 ```lua
   lvim.keys.normal_mode["<C-h>"] = false

--- a/docs/configuration/02-keybindings.md
+++ b/docs/configuration/02-keybindings.md
@@ -16,6 +16,9 @@ To modify a single Lunarvim keymapping
 ```lua
   -- X closes a buffer
   lvim.keys.normal_mode["<S-x>"] = ":BufferClose<CR>"
+  
+  -- Centers cursor when moving 1/2 page down
+  lvim.keys.normal_mode["<C-d>"] = "<C-d>zz"
 ```
 
 To remove keymappings set by Lunarvim

--- a/versioned_docs/version-1.2/configuration/02-keybindings.md
+++ b/versioned_docs/version-1.2/configuration/02-keybindings.md
@@ -1,5 +1,8 @@
 # Keybindings
 
+Use `<Leader>Lk` to view the keybindings set by Lunarvim.
+See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
+
 ## Leader Key
 
 The default leader key is `Space`. This can be changed with the following
@@ -8,26 +11,7 @@ The default leader key is `Space`. This can be changed with the following
 lvim.leader = "space"
 ```
 
-Use `<Leader>Lk` to view the keybindings set by Lunarvim.
-See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
-
-To modify a single Lunarvim keymapping
-
-```lua
-  -- X closes a buffer
-  lvim.keys.normal_mode["<S-x>"] = ":BufferClose<CR>"
-```
-
-To remove keymappings set by Lunarvim
-
-```lua
-  lvim.keys.normal_mode["<C-h>"] = false
-  lvim.keys.normal_mode["<C-j>"] = false
-  lvim.keys.normal_mode["<C-k>"] = false
-  lvim.keys.normal_mode["<C-l>"] = false
-```
-
-### Listing what is mapped
+## Listing what is mapped
 
 Use `<Leader>Lk` to view the keybindings set by Lunarvim.
 
@@ -47,27 +31,48 @@ Or just list every mapping
 :map
 ```
 
-## Explorer Bindings
+## (Re)mapping keys
 
-To view keybindings for the nvimtree plugin. Make sure you're in an nvimtree buffer and type `g?` to toggle the keybindings help
+```lua
+  -- X closes a buffer
+  lvim.keys.normal_mode["<S-x>"] = ":BufferKill<CR>"
+
+  -- Centers cursor when moving 1/2 page down
+  lvim.keys.normal_mode["<C-d>"] = "<C-d>zz"
+```
+
+## Removing default mappings
+
+```lua
+  lvim.keys.normal_mode["<C-h>"] = false
+  lvim.keys.normal_mode["<C-j>"] = false
+  lvim.keys.normal_mode["<C-k>"] = false
+  lvim.keys.normal_mode["<C-l>"] = false
+```
 
 ## LSP Bindings
 
 To modify your LSP keybindings use `lvim.lsp.buffer_mappings.[normal|visual|insert]_mode`.
 
 ### (Re)map a key
+
 Map your own functionality
+
 ```lua
 lvim.lsp.buffer_mappings.normal_mode['H'] = { vim.lsp.buf.hover, "Show documentation" }
 ```
+
 Or map default functionality to a different key
+
 ```lua
 lvim.lsp.buffer_mappings.normal_mode['gk'] = lvim.lsp.buffer_mappings.normal_mode['K']
 ```
 
 ### Remove a binding
+
 LSP bindings take precedence over regular keybindings. So in order to use a key for a regular binding, we have to remove
 it first
+
 ```lua
 lvim.lsp.buffer_mappings.normal_mode['K'] = nil
 lvim.keys.normal_mode['K'] = "<Cmd>echo Okay!<CR>"
@@ -87,11 +92,13 @@ lvim.builtin.which_key.mappings["P"] = {
   "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects"
 }
 ```
+
 As stated above, the leader key is included. So for the above example, the keybinding becomes `<leader>P`
 
 ### Removing a single mapping
 
 Remove a single Whichkey keybind
+
 ```lua
 lvim.builtin.which_key.mappings['w'] = {}
 ```
@@ -127,17 +134,18 @@ To clear all whichkey bindings and replace all mappings with your own, use this 
 ```lua
 lvim.builtin.which_key.mappings = {
   ["c"] = { "<cmd>BufferClose!<CR>", "Close Buffer" },
-  ["e"] = { "<cmd>lua require'core.nvimtree'.toggle_tree()<CR>", "Explorer" },
+  ["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" },
   ["h"] = { '<cmd>let @/=""<CR>', "No Highlight" },
 
   p = {
     name = "Packer",
     c = { "<cmd>PackerCompile<cr>", "Compile" },
     i = { "<cmd>PackerInstall<cr>", "Install" },
-    r = { "<cmd>lua require('lv-utils').reload_lv_config()<cr>", "Reload" },
+    r = { "<cmd>LvimReload<cr>", "Reload" },
     s = { "<cmd>PackerSync<cr>", "Sync" },
     u = { "<cmd>PackerUpdate<cr>", "Update" },
   },
 }
 ```
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BdoizYjJHis" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>

--- a/versioned_docs/version-1.2/configuration/02-keybindings.md
+++ b/versioned_docs/version-1.2/configuration/02-keybindings.md
@@ -1,7 +1,6 @@
 # Keybindings
 
-Use `<Leader>Lk` to view the keybindings set by Lunarvim.
-See the [keybind overview](../03-keybind-overview.md) for most commonly use keybinds
+See the [keybind overview](../03-keybind-overview.md) for most commonly used keybinds
 
 ## Leader Key
 
@@ -33,6 +32,8 @@ Or just list every mapping
 
 ## (Re)mapping keys
 
+To modify or add a keymapping:
+
 ```lua
   -- X closes a buffer
   lvim.keys.normal_mode["<S-x>"] = ":BufferKill<CR>"
@@ -42,6 +43,8 @@ Or just list every mapping
 ```
 
 ## Removing default mappings
+
+To remove keymappings set by Lunarvim:
 
 ```lua
   lvim.keys.normal_mode["<C-h>"] = false


### PR DESCRIPTION
Adds an additional example for neovim / vim newbies, such as myself, as to how to modify keybindings using lvim's native config methods.

This is a good example because:
* It is on its own a useful command, and so may appear in searches (SEO and internal search)
* Demonstrates that key maps can be assigned to keys, not just :commands, which is what I mistakingly thought when reading the lone example