### PR TITLE
docs(installation): add try it first in docker in nightly mode

### DIFF
--- a/versioned_docs/version-1.2/01-installation.md
+++ b/versioned_docs/version-1.2/01-installation.md
@@ -64,6 +64,15 @@ Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/uti
 ```
 
 </TabItem>
+<TabItem value="docker" label="Try it first in Docker!">
+
+_This is intended just to take a look at the base functionalities, so some interactions may be blocked by the environment._
+
+```bash
+docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk bash --update && bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh) && /root/.local/bin/lvim'
+```
+
+</TabItem>
 </Tabs>
 
 Make sure to check the [troubleshooting](./troubleshooting/README.md) section if you encounter any problem.


### PR DESCRIPTION
In order to follow the recent inclusion of an easy way to test stable version of LunarVim in a Docker container, this PR was made.

It adds same process described in [PR288](https://github.com/LunarVim/lunarvim.org/pull/288).