### PR TITLE
ci(plugin): run ci only for lunarvim org

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
+    if: github.repository.owner == 'LunarVim'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Run deployment CI only when repo owner is LunarVim.