### PR TITLE
docs: separate uninstall scripts

### DIFF
--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -77,7 +77,9 @@ You can remove LunarVim (including the configuration files) using the bundled `u
 
 ```bash
 bash ~/.local/share/lunarvim/lvim/utils/installer/uninstall.sh
-# or
+```
+#### **or**
+```
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/uninstall.sh)
 ```
 

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -27,17 +27,7 @@ LV_BRANCH='release-1.2/neovim-0.8' bash <(curl -s https://raw.githubusercontent.
 <TabItem value="windows" label="Windows">
 
 ```powershell
-$LV_BRANCH='release-1.2/neovim-0.8'; Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
-```
-
-</TabItem>
-
-<TabItem value="docker" label="Try it first in Docker!">
-
-_This is intended just to take a look at the base functionalities, so some interactions may be blocked by the environment._
-
-```bash
-docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk bash --update && LV_BRANCH='release-1.2/neovim-0.8' bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh) && /root/.local/bin/lvim'
+pwsh -c "`$LV_BRANCH='release-1.2/neovim-0.8'; iwr https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | iex"
 ```
 
 </TabItem>
@@ -60,7 +50,7 @@ bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/
 <TabItem value="windows" label="Windows">
 
 ```powershell
-Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
+pwsh -c "iwr https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | iex"
 ```
 
 </TabItem>
@@ -87,9 +77,7 @@ You can remove LunarVim (including the configuration files) using the bundled `u
 
 ```bash
 bash ~/.local/share/lunarvim/lvim/utils/installer/uninstall.sh
-```
-#### **or**
-```
+# or
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/uninstall.sh)
 ```
 

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -27,7 +27,17 @@ LV_BRANCH='release-1.2/neovim-0.8' bash <(curl -s https://raw.githubusercontent.
 <TabItem value="windows" label="Windows">
 
 ```powershell
-pwsh -c "`$LV_BRANCH='release-1.2/neovim-0.8'; iwr https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | iex"
+$LV_BRANCH='release-1.2/neovim-0.8'; Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
+```
+
+</TabItem>
+
+<TabItem value="docker" label="Try it first in Docker!">
+
+_This is intended just to take a look at the base functionalities, so some interactions may be blocked by the environment._
+
+```bash
+docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk bash --update && LV_BRANCH='release-1.2/neovim-0.8' bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh) && /root/.local/bin/lvim'
 ```
 
 </TabItem>
@@ -50,7 +60,7 @@ bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/
 <TabItem value="windows" label="Windows">
 
 ```powershell
-pwsh -c "iwr https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | iex"
+Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
 ```
 
 </TabItem>
@@ -77,7 +87,9 @@ You can remove LunarVim (including the configuration files) using the bundled `u
 
 ```bash
 bash ~/.local/share/lunarvim/lvim/utils/installer/uninstall.sh
-# or
+```
+#### **or**
+```
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/uninstall.sh)
 ```
 

--- a/versioned_docs/version-1.2/01-installation.md
+++ b/versioned_docs/version-1.2/01-installation.md
@@ -87,7 +87,9 @@ You can remove LunarVim (including the configuration files) using the bundled `u
 
 ```bash
 bash ~/.local/share/lunarvim/lvim/utils/installer/uninstall.sh
-# or
+```
+#### **or**
+```
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/uninstall.sh)
 ```
 


### PR DESCRIPTION
Separated Uninstall script for convenient copy-pasting

Previously:
```
bash ~/.local/share/lunarvim/lvim/utils/installer/uninstall.sh
# or
bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/uninstall.sh)
```

Two alternative scripts in the same code field defeats the purpose of copy pasting. So the two alternatives are separated into:

</br>

```
bash ~/.local/share/lunarvim/lvim/utils/installer/uninstall.sh
```
**or**
```
bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/uninstall.sh)
```
The users can now readily use the copy button provided.