### PR TITLE
docs(keybindings): fix typo

### DIFF
--- a/docs/03-keybind-overview.md
+++ b/docs/03-keybind-overview.md
@@ -14,13 +14,21 @@ Also see:
 **TIP:** Non-leader keybindings (for e.g. `<C-\>`, mentioned below and others) can be viewed
 by pressing `<backspace>` in the which-key main menu (first popup after pressing `<leader>`)
 
+**TIP:** For LazyGit `<leader>gg` to work, you must have it installed first. [Install guide](https://github.com/jesseduffield/lazygit#installation)
+
+and also have the builtin terminal enabled in your `config.lua`
+
+```lua
+lvim.builtin.terminal.active = true
+```
+
 ## Plugins
 
 | key                 | description                                                                              | mode   |
 | ------------------- | ---------------------------------------------------------------------------------------- | ------ |
 | `<leader>`          | [whichkey](https://github.com/folke/which-key.nvim) (keybinds popup (shows up after 1s)) | normal |
 | `<leader>e`         | [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)              | normal |
-| `<leader>f`         | [telesope](https://github.com/nvim-telescope/telescope.nvim) (find files)                | normal |
+| `<leader>f`         | [telescope](https://github.com/nvim-telescope/telescope.nvim) (find files)               | normal |
 | `<leader>;`         | [alpha](https://github.com/goolord/alpha-nvim) (dashboard)                               | normal |
 | `<C-\>` `<M-1/2/3>` | [toggleterm](https://github.com/akinsho/toggleterm.nvim) (terminal)                      | normal |
 
@@ -82,6 +90,25 @@ by pressing `<backspace>` in the which-key main menu (first popup after pressing
 | `<leader>sr` | open recent files         | normal |
 | `<leader>pS` | list of installed plugins | normal |
 
-## [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)
+## File explorer ([nvimtree](https://github.com/nvim-tree/nvim-tree.lua))
 
 `g?` show keybindings
+
+## Git
+
+| key          | description                    | mode   |
+| ------------ | ------------------------------ | ------ |
+| `<leader>gg` | open lazygit                   | normal |
+| `<leader>gj` | next hunk                      | normal |
+| `<leader>gk` | previous hunk                  | normal |
+| `<leader>gl` | blame line                     | normal |
+| `<leader>gp` | preview hunk                   | normal |
+| `<leader>gr` | reset hunk                     | normal |
+| `<leader>gR` | reset buffer                   | normal |
+| `<leader>gs` | stage hunk                     | normal |
+| `<leader>gu` | undo stage hunk                | normal |
+| `<leader>go` | open changed file              | normal |
+| `<leader>gb` | checkout branch                | normal |
+| `<leader>gc` | checkout commit                | normal |
+| `<leader>gC` | checkout commit (current file) | normal |
+| `<leader>gd` | show diff                      | normal |

--- a/docs/03-keybind-overview.md
+++ b/docs/03-keybind-overview.md
@@ -14,14 +14,6 @@ Also see:
 **TIP:** Non-leader keybindings (for e.g. `<C-\>`, mentioned below and others) can be viewed
 by pressing `<backspace>` in the which-key main menu (first popup after pressing `<leader>`)
 
-**TIP:** For LazyGit `<leader>gg` to work, you must have it installed first. [Install guide](https://github.com/jesseduffield/lazygit#installation)
-
-and also have the builtin terminal enabled in your `config.lua`
-
-```lua
-lvim.builtin.terminal.active = true
-```
-
 ## Plugins
 
 | key                 | description                                                                              | mode   |
@@ -90,25 +82,6 @@ lvim.builtin.terminal.active = true
 | `<leader>sr` | open recent files         | normal |
 | `<leader>pS` | list of installed plugins | normal |
 
-## File explorer ([nvimtree](https://github.com/nvim-tree/nvim-tree.lua))
+## [nvimtree](https://github.com/nvim-tree/nvim-tree.lua) (side file explorer)
 
 `g?` show keybindings
-
-## Git
-
-| key          | description                    | mode   |
-| ------------ | ------------------------------ | ------ |
-| `<leader>gg` | open lazygit                   | normal |
-| `<leader>gj` | next hunk                      | normal |
-| `<leader>gk` | previous hunk                  | normal |
-| `<leader>gl` | blame line                     | normal |
-| `<leader>gp` | preview hunk                   | normal |
-| `<leader>gr` | reset hunk                     | normal |
-| `<leader>gR` | reset buffer                   | normal |
-| `<leader>gs` | stage hunk                     | normal |
-| `<leader>gu` | undo stage hunk                | normal |
-| `<leader>go` | open changed file              | normal |
-| `<leader>gb` | checkout branch                | normal |
-| `<leader>gc` | checkout commit                | normal |
-| `<leader>gC` | checkout commit (current file) | normal |
-| `<leader>gd` | show diff                      | normal |


### PR DESCRIPTION
This patch adds a new Git section to the Keybind overview page it shows all default git keymaps and tips to enable lazygit

Small fixes:

- Rename file explorer section to better match the other sections capitalization/style
- Fix typo on line 31 "telesope" -> "telescope"

Fixes: #319

---

The info about enabling the builtin terminal was added because the `config_win.example.lua` used to come with it disabled before the PR [#3519](https://github.com/LunarVim/LunarVim/pull/3519#issue-1461993179) on LunarVim.

| LazyGit Tips             |  Section rename | New Git section
:-------------------------:|:-------------------------:|:------------
![add-git-tips](https://user-images.githubusercontent.com/43862225/210074361-324feb00-a082-480a-93e5-341dfcdb192b.png) | ![fix-name-section](https://user-images.githubusercontent.com/43862225/210074363-ff72dc3d-3e24-4a82-b16b-5eec541c485a.png) | ![git-section](https://user-images.githubusercontent.com/43862225/210074365-9f603284-8a58-4e96-a578-b78046957ffe.png)

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows 

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
