### PR TITLE
fix: clearer hero CTA buttons

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,8 +91,8 @@ const config = {
     },
     // secondary call to action is optional
     secondaryCTA: {
-      text: "Support",
-      to: "/donate",
+      text: "Get Help",
+      to: "https://discord.gg/Xb9B4Ny",
     },
     heroImage: {
       src: "/img/lunarvim_logo.png",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,10 +89,14 @@ const config = {
       text: "Install",
       to: "/docs/installation",
     },
-    // secondary call to action is optional
+    // secondary and tertiary call to action is optional
     secondaryCTA: {
       text: "Get Help",
       to: "https://discord.gg/Xb9B4Ny",
+    },
+    tertiaryCTA: {
+      text: "Donate",
+      to: "/donate",
     },
     heroImage: {
       src: "/img/lunarvim_logo.png",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ const config = {
       text: "Install",
       to: "/docs/installation",
     },
-    // secondary and tertiary call to action is optional
+    // secondary and tertiary calls to action are optional
     secondaryCTA: {
       text: "Get Help",
       to: "https://discord.gg/Xb9B4Ny",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,12 +91,12 @@ const config = {
     },
     // secondary and tertiary calls to action are optional
     secondaryCTA: {
-      text: "Get Help",
-      to: "https://discord.gg/Xb9B4Ny",
-    },
-    tertiaryCTA: {
       text: "Donate",
       to: "/donate",
+    },
+    tertiaryCTA: {
+      text: "Get Help",
+      to: "https://discord.gg/Xb9B4Ny",
     },
     heroImage: {
       src: "/img/lunarvim_logo.png",

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -58,7 +58,7 @@ const Hero = () => {
               ) : null}
               {tertiaryCTA ? (
                 <Link
-                  className={`button button--outline button--lg ${snowBtn ? styles.snowBtn : ""
+                  className={`button button--link button--lg ${snowBtn ? styles.snowBtn : ""
                     }`}
                   to={tertiaryCTA.to}
                 >

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -17,6 +17,7 @@ const Hero = () => {
       customFields: {
         primaryCTA,
         secondaryCTA,
+        tertiaryCTA,
         heroImage,
         christmas: { snowBtn },
       },
@@ -53,6 +54,15 @@ const Hero = () => {
                   to={secondaryCTA.to}
                 >
                   <Translate>{secondaryCTA.text}</Translate>
+                </Link>
+              ) : null}
+              {tertiaryCTA ? (
+                <Link
+                  className={`button button--outline button--lg ${snowBtn ? styles.snowBtn : ""
+                    }`}
+                  to={tertiaryCTA.to}
+                >
+                  <Translate>{tertiaryCTA.text}</Translate>
                 </Link>
               ) : null}
             </div>


### PR DESCRIPTION
There was confusion in the discord about the support button: is it for supporting the user or lunarvim.
this pr adds a `Get Help` button and rewords `Support` to `Donate` to make it clearer