### PR TITLE
fix(MeetTheTeam): css class priority

### DIFF
--- a/src/components/MeetTheTeam/styles.modules.css
+++ b/src/components/MeetTheTeam/styles.modules.css
@@ -65,7 +65,7 @@
   opacity: 0;
 }
 
-.image--show {
+.image-container .image--show {
   opacity: 1;
 }
 


### PR DESCRIPTION
In the optimized build the images don't show because `.image--show` has lower priority than `.image`, idk why that is but this fixes it