### PR TITLE
docs: format_on_save autocmd pattern and overriding hlgroups

### DIFF
--- a/docs/configuration/appearance/colorschemes.md
+++ b/docs/configuration/appearance/colorschemes.md
@@ -6,25 +6,44 @@ sidebar_position: 1
 
 ## Switching colors
 
-To switch color schemes on the fly, type the following command:
+To switch color schemes on the fly, use `leader s c` (`:Telescope colorscheme`)
 
-```vim
-:Telescope colorscheme
-```
-
-You can also press `Space` `s` `p` to cycle through colorschemes with a preview.
+You can also press `leader s p` to cycle through colorschemes with a preview.
 
 To change the color scheme permanently, modify `config.lua`
 
 ```lua
-lvim.colorscheme = 'desert'
+lvim.colorscheme = "desert"
 ```
 
 ## Installing colorschemes
 
-You can add any colorscheme you like. Just add a plugin with the colorscheme of your choice. For more information on installing plugins [look here. ](../plugins/plugins.md)
+You can add any colorscheme you like. Just add a plugin with the colorscheme of your choice. For more information on installing plugins [look here.](../plugins/plugins.md)
 
 [This is a list](https://github.com/rockerBOO/awesome-neovim#colorscheme) of colorschemes with tree-sitter support
+
+## Customizing some colors
+
+You can customize the highlight groups by overriding them in an autocommand.
+To find the group you want to change use `leader s H` (`:Telescope highlights`),
+`:TSHighlightCapturesUnderCursor` or `:Inspect`
+
+```lua
+lvim.autocommands = {
+  {
+    { "ColorScheme" },
+    {
+      pattern = "*",
+      callback = function()
+        -- change `Normal` to the group you want to change
+        -- and `#ffffff` to the color you want
+        -- see `:h nvim_set_hl` for more options
+        vim.api.nvim_set_hl(0, "Normal", { bg = "#ffffff", underline = false, bold = true })
+      end,
+    },
+  },
+}
+```
 
 ## Transparent Windows
 

--- a/docs/configuration/language-features/linting-and-formatting.md
+++ b/docs/configuration/language-features/linting-and-formatting.md
@@ -64,8 +64,15 @@ Let's take `python` as an example:
 
 ## Formatting on save
 
-To enable formatting on save:
+- To enable formatting on save:
 
-```lua
-lvim.format_on_save = true
-```
+  ```lua
+  lvim.format_on_save.enabled = true
+  ```
+
+- Only enable it for certain filetypes
+
+  ```lua
+  lvim.format_on_save.enabled = true
+  lvim.format_on_save.pattern = { "*.lua", "*.py" }
+  ```


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
