### PR TITLE
docs: Add docs for whichkey preset enablement

### DIFF
--- a/docs/configuration/keybindings.md
+++ b/docs/configuration/keybindings.md
@@ -159,6 +159,29 @@ lvim.builtin.which_key.mappings = {
   },
 }
 ```
+### Enable whichkey presets
+
+Whichkey containts default presets that are **disabled** by default in LunarVim.
+
+```
+presets = {
+      operators = false, -- adds help for operators like d, y, ... and registers them for motion / text object completion
+      motions = false, -- adds help for motions
+      text_objects = false, -- help for text objects triggered after entering an operator
+      windows = false, -- default bindings on <c-w>
+      nav = false, -- misc bindings to work with windows
+      z = false, -- bindings for folds, spelling and others prefixed with z
+      g = false, -- bindings for prefixed with g
+    },
+```
+
+To enable the whichkey presets:
+
+`lvim.builtin.which_key.setup.plugins.presets.<preset-name> = true`
+
+Example:
+
+`lvim.builtin.which_key.setup.plugins.presets.z = true`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BdoizYjJHis" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
 

--- a/docs/configuration/keybindings.md
+++ b/docs/configuration/keybindings.md
@@ -161,7 +161,7 @@ lvim.builtin.which_key.mappings = {
 ```
 ### Enable whichkey presets
 
-Whichkey containts default presets that are **disabled** by default in LunarVim.
+Whichkey contains default presets that are **disabled** by default in LunarVim.
 
 ```
 presets = {

--- a/versioned_docs/version-1.2/configuration/keybindings.md
+++ b/versioned_docs/version-1.2/configuration/keybindings.md
@@ -160,6 +160,29 @@ lvim.builtin.which_key.mappings = {
   },
 }
 ```
+### Enable whichkey presets
+
+Whichkey containts default presets that are **disabled** by default in LunarVim.
+
+```
+presets = {
+      operators = false, -- adds help for operators like d, y, ... and registers them for motion / text object completion
+      motions = false, -- adds help for motions
+      text_objects = false, -- help for text objects triggered after entering an operator
+      windows = false, -- default bindings on <c-w>
+      nav = false, -- misc bindings to work with windows
+      z = false, -- bindings for folds, spelling and others prefixed with z
+      g = false, -- bindings for prefixed with g
+    },
+```
+
+To enable the whichkey presets:
+
+`lvim.builtin.which_key.setup.plugins.presets.<preset-name> = true`
+
+Example:
+
+`lvim.builtin.which_key.setup.plugins.presets.z = true`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BdoizYjJHis" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
 

--- a/versioned_docs/version-1.2/configuration/keybindings.md
+++ b/versioned_docs/version-1.2/configuration/keybindings.md
@@ -162,7 +162,7 @@ lvim.builtin.which_key.mappings = {
 ```
 ### Enable whichkey presets
 
-Whichkey containts default presets that are **disabled** by default in LunarVim.
+Whichkey contains default presets that are **disabled** by default in LunarVim.
 
 ```
 presets = {


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
