### PR TITLE
refactor: remove "new release" announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -193,14 +193,14 @@ const config = {
           'python',
         ],
       },
-      announcementBar: {
-        id: 'new_release_1.2',
-        content:
-          'New Release! <a target="_blank" rel="noopener noreferrer" href="https://github.com/LunarVim/LunarVim">install</a>',
-        backgroundColor: 'var(--primary-fg)',
-        textColor: 'var(--primary-bg)',
-        isCloseable: true,
-      },
+      // announcementBar: {
+      //   id: 'new_release_1.2',
+      //   content:
+      //     'New Release! <a target="_blank" rel="noopener noreferrer" href="https://github.com/LunarVim/LunarVim">install</a>',
+      //   backgroundColor: 'var(--primary-fg)',
+      //   textColor: 'var(--primary-bg)',
+      //   isCloseable: true,
+      // },
     }),
   plugins: [
     [


### PR DESCRIPTION
1.2 is not new anymore, I commented out the bar so it's easier to add it next time
