### PR TITLE
docs(example-plugins): replace nvim-ts-rainbow with maintaned fork

### DIFF
--- a/docs/configuration/plugins/example-configurations.md
+++ b/docs/configuration/plugins/example-configurations.md
@@ -377,13 +377,13 @@ vim.keymap.set('n', ',W', swap_windows, { desc = 'Swap windows' })
 },
 ```
 
-### [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
+### [nvim-ts-rainbow](https://github.com/mrjones2014/nvim-ts-rainbow)
 
 **rainbow parentheses**
 
 ```lua
 {
-  "p00f/nvim-ts-rainbow",
+  "mrjones2014/nvim-ts-rainbow",
 },
 ```
 

--- a/versioned_docs/version-1.2/plugins/extra-plugins.md
+++ b/versioned_docs/version-1.2/plugins/extra-plugins.md
@@ -410,13 +410,13 @@ vim.keymap.set('n', ',W', swap_windows, { desc = 'Swap windows' })
 },
 ```
 
-### [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
+### [nvim-ts-rainbow](https://github.com/mrjones2014/nvim-ts-rainbow)
 
 **rainbow parentheses**
 
 ```lua
 {
-  "p00f/nvim-ts-rainbow",
+  "mrjones2014/nvim-ts-rainbow",
 },
 ```
 


### PR DESCRIPTION
[CHECKLIST]

[x] I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)

[x] I prefixed the title with one of the following tags:
 - docs: on documentation updates

the original plugin maintainer has archived the repo and encouraged anybody to take over. the fork replacing the original here does that egregiously. installed and working on my setup.
