### PR TITLE
docs(example-plugins): adding nvim-neo-tree alternative to nvim-tree

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -4,11 +4,14 @@ autoselect
 buftype
 codebase
 cursorline
+dotfiles
+filesystem
 frontend
 func
 fzf
 fzy
 Github
+gitignored
 highlighter
 hrsh
 hsl
@@ -34,4 +37,3 @@ uelic
 vheight
 vimgrep
 vsplit
-winblend

--- a/docs/configuration/plugins/example-configurations.md
+++ b/docs/configuration/plugins/example-configurations.md
@@ -132,6 +132,55 @@ For a more lightweight, easier-to-use alternative, check out the author's new, w
 },
 ```
 
+### [neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
+
+**neo-tree is a plugin to manage the file system and other tree like structures**
+
+```lua
+{
+  "nvim-neo-tree/neo-tree.nvim",
+  branch = "v2.x",
+  requires = {
+    "nvim-lua/plenary.nvim",
+    "nvim-tree/nvim-web-devicons",
+    "MunifTanjim/nui.nvim",
+  },
+  config = function()
+    require("neo-tree").setup({
+      close_if_last_window = true,
+      window = {
+        width = 30,
+      },
+      buffers = {
+        follow_current_file = true,
+      },
+      filesystem = {
+        follow_current_file = true,
+        filtered_items = {
+          hide_dotfiles = false,
+          hide_gitignored = false,
+          hide_by_name = {
+            "node_modules"
+          },
+          never_show = {
+            ".DS_Store",
+            "thumbs.db"
+          },
+        },
+      },
+    })
+  end
+},
+```
+
+After installing ensure to disable `nvim-tree` it in your `config.lua` using:
+
+```
+...
+lvim.builtin.nvimtree.active = false -- NOTE: using neo-tree
+...
+```
+
 ### [rnvimr](https://github.com/kevinhwang91/rnvimr)
 
 **ranger file explorer window**

--- a/docs/configuration/plugins/example-configurations.md
+++ b/docs/configuration/plugins/example-configurations.md
@@ -140,7 +140,7 @@ For a more lightweight, easier-to-use alternative, check out the author's new, w
 {
   "nvim-neo-tree/neo-tree.nvim",
   branch = "v2.x",
-  requires = {
+  dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-tree/nvim-web-devicons",
     "MunifTanjim/nui.nvim",

--- a/docs/configuration/plugins/example-configurations.md
+++ b/docs/configuration/plugins/example-configurations.md
@@ -175,7 +175,7 @@ For a more lightweight, easier-to-use alternative, check out the author's new, w
 
 After installing ensure to disable `nvim-tree` it in your `config.lua` using:
 
-```
+```lua
 ...
 lvim.builtin.nvimtree.active = false -- NOTE: using neo-tree
 ...

--- a/versioned_docs/version-1.2/plugins/extra-plugins.md
+++ b/versioned_docs/version-1.2/plugins/extra-plugins.md
@@ -168,6 +168,55 @@ lvim.autocommands = {
 },
 ```
 
+### [neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
+
+**neo-tree is a plugin to manage the file system and other tree like structures**
+
+```lua
+{
+  "nvim-neo-tree/neo-tree.nvim",
+  branch = "v2.x",
+  requires = {
+    "nvim-lua/plenary.nvim",
+    "nvim-tree/nvim-web-devicons",
+    "MunifTanjim/nui.nvim",
+  },
+  config = function()
+    require("neo-tree").setup({
+      close_if_last_window = true,
+      window = {
+        width = 30,
+      },
+      buffers = {
+        follow_current_file = true,
+      },
+      filesystem = {
+        follow_current_file = true,
+        filtered_items = {
+          hide_dotfiles = false,
+          hide_gitignored = false,
+          hide_by_name = {
+            "node_modules"
+          },
+          never_show = {
+            ".DS_Store",
+            "thumbs.db"
+          },
+        },
+      },
+    })
+  end
+},
+```
+
+After installing ensure to disable `nvim-tree` it in your `config.lua` using:
+
+```
+...
+lvim.builtin.nvimtree.active = false -- NOTE: using neo-tree
+...
+```
+
 ### [rnvimr](https://github.com/kevinhwang91/rnvimr)
 
 **ranger file explorer window**

--- a/versioned_docs/version-1.2/plugins/extra-plugins.md
+++ b/versioned_docs/version-1.2/plugins/extra-plugins.md
@@ -211,7 +211,7 @@ lvim.autocommands = {
 
 After installing ensure to disable `nvim-tree` it in your `config.lua` using:
 
-```
+```lua
 ...
 lvim.builtin.nvimtree.active = false -- NOTE: using neo-tree
 ...


### PR DESCRIPTION
[CHECKLIST]
 - [x] I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
 - [x] I prefixed the title with docs: on documentation updates

neo-tree is an amazing alternative to nvim-tree. been using it for a long while and never had issues. it also offers a wider feature set and works flawlessly. I used the stable branch in my config, as neo-tree cares about that to provide solid software.

hope this helps.