### PR TITLE
docs(languages): Add docs for customer linters and formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 
+Requires Node >v16.14
+
 ### Installation
 
 ```

--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -315,3 +315,39 @@ You can disable auto-command and is to true by default.
 ```lua
 lvim.format_on_save = true
 ```
+
+### Registering custom linters/formatters
+
+LunarVim supports all linters and formatters defined as builtins to null-ls, however there may be occasions where you want to run a linter/formatter that null-ls does not support.
+
+Refer to various docs in the null-ls repo for details on [configuring built-in sources](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md) and [helpers for making builtins](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/HELPERS.md#make_builtin).
+
+:::tip
+Do not load registered, custom linters/formatters in your [LunarVim config](https://www.lunarvim.org/docs/languages#lintingformatting) (i.e. in the `formatters.setup` block). Doing so will raise an error that a `builtin source could not be found`.
+:::
+
+Below is an example registering the [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) formatter:
+
+```lua
+local helpers = require("null-ls.helpers")
+local FORMATTING = require("null-ls.methods").internal.FORMATTING
+
+require("null-ls").register({
+  --your custom sources go here
+  helpers.make_builtin({
+    name = "htmlbeautifier",
+    meta = {
+      url = "https://github.com/threedaymonk/htmlbeautifier",
+      description = "A normaliser/beautifier for HTML that also understands embedded Ruby. Ideal for tidying up Rails templates."
+    },
+    method = FORMATTING,
+    filetypes = { "eruby" },
+    generator_opts = {
+      command = "htmlbeautifier",
+      args = {} -- put any required arguments in this table
+      to_stdin = true, -- instructs the command to ingest the file from STDIN (i.e. run the currently open buffer through the linter/formatter)
+    },
+    factory = helpers.formatter_factory,
+  })
+})
+```


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->

Add documentation for registering a custom linter/formatter in null-ls.

Also included minimun Node version in README.