### PR TITLE
docs(installer): Root-less Docker installation, able to install everything

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -40,7 +40,7 @@ pwsh -c "`$LV_BRANCH='release-1.2/neovim-0.8'; iwr https://raw.githubusercontent
 _This is intended just to take a look at the base functionalities, so some interactions may be blocked by the environment._
 
 ```bash
-docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk bash --update && LV_BRANCH='release-1.2/neovim-0.8' bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/fc6873809934917b470bff1b072171879899a36b/utils/installer/install.sh) && /root/.local/bin/lvim'
+docker run -w /tmp -it --rm alpine:edge sh -uelic 'addgroup -S lunaruser && adduser -S lunaruser -G lunaruser --shell /bin/sh && apk add yarn git python3 cargo neovim ripgrep alpine-sdk bash --update && LV_BRANCH='release-1.2/neovim-0.8' su -c "bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/fc6873809934917b470bff1b072171879899a36b/utils/installer/install.sh)" lunaruser && su -c /home/lunaruser/.local/bin/lvim lunaruser'
 ```
 
 </TabItem>


### PR DESCRIPTION
Hello everyone!

I am a long-time vanilla vim user, and curious about LunarVim :) Here is some context for this PR: While testing LunarVim I was happy to see that a Docker command was made available. Since I have PTSD from breaking stuff by installing new stuff, I dockerize a lot of things.

Once I launched it, I got frustrated because I couldn't install every suggestion and felt perplexed that the container was running as root to launch the install script. Since it's only a demo, I didn't really want it to be unnecessarily privileged on my machine.

To answer these points, I suggest the following:
- Add yarn, python3, and cargo as dependencies
- Add the lunaruser and wrap the install and run commands with `su`.

WDYT?

Cheers!

Loris
