### PR TITLE
docs(keybinds-overview): add tips for meta key in macOS

### DIFF
--- a/docs/beginners-guide/keybinds-overview.md
+++ b/docs/beginners-guide/keybinds-overview.md
@@ -15,6 +15,8 @@ Also see:
 
 **TIP:** `<M>` is `alt` on Windows/Linux and `option` on MacOS
 
+**TIP:** If you happen to be using iTerm2, take note that <M> requires the `option` key to be mapped to `Esc+` in Preferences - Profiles - Keys for proper functioning in both the terminal and tmux
+
 **TIP:** Non-leader keybindings (for e.g. `<C-\>`, mentioned below and others) can be viewed
 by pressing `<backspace>` in the which-key main menu (first popup after pressing `<leader>`)
 


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows



[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->



Tips for macOS users, the option key to be mapped to ensure the functions of `<M>` key.