### PR TITLE
docs(installation): Add Optional Feature Pre-reqs: lazygit

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -11,6 +11,9 @@ sidebar_position: 1
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (for Windows)
 
+## Optional Feature Pre-reqs
+- Install [`lazygit`](https://github.com/jesseduffield/lazygit#installation). This enables `<leader>gg` to launch `lazygit` for intergrated and enhanced Git experience while in `lvim`.
+
 ## Release
 
 (Neovim 0.8.0)

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (for Windows)
 
-## Optional Feature Pre-reqs
+## Optional Feature Prerequisites
 - Install [`lazygit`](https://github.com/jesseduffield/lazygit#installation). This enables `<leader>gg` to launch `lazygit` for intergrated and enhanced Git experience while in `lvim`.
 
 ## Release


### PR DESCRIPTION
Having a reference to this somewhere during installation for something that is built-in to the `<Leader>` suggestions.

Someone may not want to use or install it but having a reference for a feature that is built-in to the default installation of LunarVim is helpful.

Wording can be updated as the maintainers deem fit

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
