### PR TITLE
docs: Missing dependencies trying with docker

### DIFF
--- a/versioned_docs/version-1.2/installation.md
+++ b/versioned_docs/version-1.2/installation.md
@@ -40,7 +40,7 @@ $LV_BRANCH='release-1.2/neovim-0.8'; Invoke-WebRequest https://raw.githubusercon
 _This is intended just to take a look at the base functionalities, so some interactions may be blocked by the environment._
 
 ```bash
-docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk bash --update && LV_BRANCH='release-1.2/neovim-0.8' bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/fc6873809934917b470bff1b072171879899a36b/utils/installer/install.sh) && /root/.local/bin/lvim'
+docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk python3 cargo bash --update && LV_BRANCH='release-1.2/neovim-0.8' bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/fc6873809934917b470bff1b072171879899a36b/utils/installer/install.sh) && /root/.local/bin/lvim'
 ```
 
 </TabItem>
@@ -72,7 +72,7 @@ Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/uti
 _This is intended just to take a look at the base functionalities, so some interactions may be blocked by the environment._
 
 ```bash
-docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk bash --update && bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh) && /root/.local/bin/lvim'
+docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep alpine-sdk python3 cargo bash --update && bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh) && /root/.local/bin/lvim'
 ```
 
 </TabItem>


### PR DESCRIPTION
Fixing missing python3 and cargo dependencie while trying lunarvim with docker.

ex for python
-------------------------------------------------------------------------------- Would you like to install LunarVim's NodeJS dependencies: neovim, tree-sitter-cli? [y]es or [n]o (default: no) : y
[WARN]: skipping installing optional nodejs dependencies due to insufficient permissions. check how to solve it: https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally -------------------------------------------------------------------------------- Would you like to install LunarVim's Python dependencies: pynvim? [y]es or [n]o (default: no) : y
Verifying that pip is available..
/dev/fd/64: line 322: python3: command not found

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
