### PR TITLE
fix(docs): Add `tagline` for Link Previews

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const socials = require('./socials');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'LunarVim',
-  description: 'An IDE layer for Neovim with sane defaults. Completely free and community driven.',
+  tagline: 'An IDE layer for Neovim with sane defaults. Completely free and community driven.',
   url: 'https://lunarvim.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,7 @@ const socials = require('./socials');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'LunarVim',
+  description: 'An IDE layer for Neovim with sane defaults. Completely free and community driven.',
   url: 'https://lunarvim.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -17,7 +17,7 @@ const Home = () => {
     <AnimationsContextProvider>
       <Layout
         title={siteConfig.title}
-        description={siteConfig.description}
+        description={siteConfig.tagline}
       >
         <main>
           <Lightrope />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -17,7 +17,7 @@ const Home = () => {
     <AnimationsContextProvider>
       <Layout
         title={siteConfig.title}
-        description="Description will go into a meta tag in <head />"
+        description={siteConfig.description}
       >
         <main>
           <Lightrope />


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
The following is what Google Messages shows when I send lunarvim.org to a friend (notice the description):
![image](https://user-images.githubusercontent.com/8365885/232120598-d4003062-5b80-4e44-8956-df2893f38f65.png)


https://docusaurus.io/docs/api/docusaurus-config#tagline

I haven't tested this yet.