### PR TITLE
Fix heading

### DIFF
--- a/docs/configuration/language-features/linting-and-formatting.md
+++ b/docs/configuration/language-features/linting-and-formatting.md
@@ -79,7 +79,7 @@ Let's take `python` as an example:
   lvim.format_on_save.pattern = { "*.lua", "*.py" }
   ```
   
-### Registering custom linters/formatters
+## Registering custom linters/formatters
 
 LunarVim supports all linters and formatters defined as builtins to null-ls, however there may be occasions where you want to run a linter/formatter that null-ls does not support.
 


### PR DESCRIPTION
Was H3 instead of H2 so was indented incorrectly on the right-hand menu.

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
