### PR TITLE
docs: clarify update branch

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -87,7 +87,9 @@ Make sure to check the [troubleshooting](../troubleshooting/README.md) section i
 
 ## Updating LunarVim
 
-- Inside LunarVim `:LvimUpdate`
+- LunarVim updates to the current LunarVim branch's latest commit.  
+- `:LvimUpdate` command in command-line mode.
+- <leader>Lu using WhichKey.  
 - From the command-line `lvim +LvimUpdate +q`
 
 ### Update the plugins

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -89,7 +89,7 @@ Make sure to check the [troubleshooting](../troubleshooting/README.md) section i
 
 - LunarVim updates to the current LunarVim branch's latest commit.  
 - `:LvimUpdate` command in command-line mode.
-- <leader>Lu using WhichKey.  
+- `<leader>Lu` using WhichKey.  
 - From the command-line `lvim +LvimUpdate +q`
 
 ### Update the plugins


### PR DESCRIPTION
Update the documentation to reflect https://github.com/LunarVim/LunarVim/blob/91bdb7cd5131bdeeb0fd68ad58aaf69adb510983/lua/lvim/utils/git.lua#LL61C3-L61C3

Currently LunarVim doesn't switch branch to the latest release automatically.

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
