### PR TITLE
Update example-configurations.md

### DIFF
--- a/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
@@ -44,7 +44,7 @@ For a more lightweight, easier-to-use alternative, check out the author's new, w
 ```lua
 {
   "ggandor/leap.nvim",
-  as = "leap",
+  name = "leap",
   config = function()
     require("leap").add_default_mappings()
   end,


### PR DESCRIPTION
fix: change the "as" to "name " since the "as" in lazy.nvim has deprecated.

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
