### PR TITLE
docs(plugins): add flutter-tools installation instructions

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -4,6 +4,7 @@ autoselect
 buftype
 codebase
 cursorline
+dartls
 dotfiles
 filesystem
 frontend

--- a/docs/configuration/plugins/example-configurations.md
+++ b/docs/configuration/plugins/example-configurations.md
@@ -1002,3 +1002,41 @@ Once installed and synced, add your WakaTime API Key via `:WakaTimeApiKey` comma
 },
 
 ```
+
+### [flutter-tools](https://github.com/tpope/vim-rails)
+
+**Build flutter and dart applications in LunarVim using the native LSP. This
+plugin provides easy launching and debugging of flutter applications, as well
+as extending LSP functionality like widget guides, widget outline view, and hot
+reloading.**
+
+```lua
+{
+  "akinsho/flutter-tools.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "stevearc/dressing.nvim", -- this is optional, but improves the appearance
+  },
+  config = function()
+    require("flutter-tools").setup {
+      settings = {
+        -- If you want flutter-specific snippets, enable them here
+        enableSnippets = true,
+      },
+      lsp = {
+        on_attach = require("lvim.lsp").common_on_attach,
+      }
+    }
+  end,
+  ft = "dart",
+},
+```
+
+You also need to prevent LunarVim from automatically configuring the `dartls`
+language server so `flutter-tools` can do it. Insert this code outside of
+`lvim.plugins`:
+
+```lua
+-- Prevent LunarVim from configuring dartls so flutter-tools can do it
+vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "dartls" })
+```

--- a/docs/configuration/plugins/example-configurations.md
+++ b/docs/configuration/plugins/example-configurations.md
@@ -1003,7 +1003,7 @@ Once installed and synced, add your WakaTime API Key via `:WakaTimeApiKey` comma
 
 ```
 
-### [flutter-tools](https://github.com/tpope/vim-rails)
+### [flutter-tools](https://github.com/akinsho/flutter-tools.nvim)
 
 **Build flutter and dart applications in LunarVim using the native LSP. This
 plugin provides easy launching and debugging of flutter applications, as well

--- a/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
@@ -1002,3 +1002,40 @@ Once installed and synced, add your WakaTime API Key via `:WakaTimeApiKey` comma
 },
 
 ```
+### [flutter-tools](https://github.com/tpope/vim-rails)
+
+**Build flutter and dart applications in LunarVim using the native LSP. This
+plugin provides easy launching and debugging of flutter applications, as well
+as extending LSP functionality like widget guides, widget outline view, and hot
+reloading.**
+
+```lua
+{
+  "akinsho/flutter-tools.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "stevearc/dressing.nvim", -- this is optional, but improves the appearance
+  },
+  config = function()
+    require("flutter-tools").setup {
+      settings = {
+        -- If you want flutter-specific snippets, enable them here
+        enableSnippets = true,
+      },
+      lsp = {
+        on_attach = require("lvim.lsp").common_on_attach,
+      }
+    }
+  end,
+  ft = "dart",
+},
+```
+
+You also need to prevent LunarVim from automatically configuring the `dartls`
+language server so `flutter-tools` can do it. Insert this code outside of
+`lvim.plugins`:
+
+```lua
+-- Prevent LunarVim from configuring dartls so flutter-tools can do it
+vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "dartls" })
+```

--- a/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
@@ -1002,6 +1002,7 @@ Once installed and synced, add your WakaTime API Key via `:WakaTimeApiKey` comma
 },
 
 ```
+
 ### [flutter-tools](https://github.com/tpope/vim-rails)
 
 **Build flutter and dart applications in LunarVim using the native LSP. This

--- a/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
@@ -1003,7 +1003,7 @@ Once installed and synced, add your WakaTime API Key via `:WakaTimeApiKey` comma
 
 ```
 
-### [flutter-tools](https://github.com/tpope/vim-rails)
+### [flutter-tools](https://github.com/akinsho/flutter-tools.nvim)
 
 **Build flutter and dart applications in LunarVim using the native LSP. This
 plugin provides easy launching and debugging of flutter applications, as well


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
I ran into trouble installing [`akinsho/flutter-tools.nvim`](https://github.com/akinsho/flutter-tools.nvim) when I started a Flutter development project, so I thought the instructions might be helpful to other developers. According to the plugin author's [documentation](https://github.com/akinsho/flutter-tools.nvim#warning), the plugin itself configures LSP, so it shouldn't be configured by LunarVim. I struggled to restore the LSP keymaps I had grown accustomed to in LunarVim, but was able to get that working with [help](https://github.com/LunarVim/LunarVim/issues/4103) from @cpea2506. This set of instructions describe a configuration that works in v1.3 to restore LunarVim's LSP keymaps.

I see in the hidden comment that docs in `/versioned-docs` are frozen, but I do think this edit would be immediately helpful to current users.