### PR TITLE
docs: add instructions for Alacritty key setting

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,3 +1,4 @@
+Alacritty
 autoclose
 autorename
 autoselect
@@ -32,7 +33,6 @@ scrolloff
 stoggleup
 strlist
 tabpage
-tmux
 todo
 tokyonight
 uelic

--- a/docs/beginners-guide/keybinds-overview.md
+++ b/docs/beginners-guide/keybinds-overview.md
@@ -13,9 +13,11 @@ Also see:
 
 **TIP:** `<leader>` is space by default, read [`:help keycodes`](https://neovim.io/doc/user/intro.html#keycodes) for more key names
 
-**TIP:** `<M>` is `alt` on Windows/Linux and `option` on MacOS
+**TIP:** `<M>` is `alt` on Windows/Linux and `option` on macOS
 
-**TIP:** If you happen to be using iTerm2, take note that `<M>` requires the `option` key to be mapped to `Esc+` in [ Preferences - Profiles - Keys ](https://github.com/LunarVim/lunarvim.org/pull/377#discussion_r1140747022) for proper functioning in both the terminal and tmux
+**TIP:** For macOS users: For the `option` key (`⌥`) to work as `<M>` you may need to adjust some settings:
+- For iTerm2: Select `Esc+` as the Option key setting in [ Preferences - Profiles - Keys ](https://github.com/LunarVim/lunarvim.org/pull/377#discussion_r1140747022)
+- For Alacritty: Make sure you're on Alacritty version >= 0.12.0. In your `alacritty.yml` config file, set `window.option_as_alt` to `Both` or `OnlyLeft` \ `OnlyRight` per your preference (https://github.com/alacritty/alacritty/issues/62).
 
 **TIP:** Non-leader keybindings (for e.g. `<C-\>`, mentioned below and others) can be viewed
 by pressing `<backspace>` in the which-key main menu (first popup after pressing `<leader>`)

--- a/versioned_docs/version-1.3/beginners-guide/keybinds-overview.md
+++ b/versioned_docs/version-1.3/beginners-guide/keybinds-overview.md
@@ -13,9 +13,11 @@ Also see:
 
 **TIP:** `<leader>` is space by default, read [`:help keycodes`](https://neovim.io/doc/user/intro.html#keycodes) for more key names
 
-**TIP:** `<M>` is `alt` on Windows/Linux and `option` on MacOS
+**TIP:** `<M>` is `alt` on Windows/Linux and `option` on macOS
 
-**TIP:** If you happen to be using iTerm2, take note that `<M>` requires the `option` key to be mapped to `Esc+` in [ Preferences - Profiles - Keys ](https://github.com/LunarVim/lunarvim.org/pull/377#discussion_r1140747022) for proper functioning in both the terminal and tmux
+**TIP:** For macOS users: For the `option` key (`⌥`) to work as `<M>` you may need to adjust some settings:
+- For iTerm2: Select `Esc+` as the Option key setting in [ Preferences - Profiles - Keys ](https://github.com/LunarVim/lunarvim.org/pull/377#discussion_r1140747022)
+- For Alacritty: Make sure you're on Alacritty version >= 0.12.0. In your `alacritty.yml` config file, set `window.option_as_alt` to `Both` or `OnlyLeft` \ `OnlyRight` per your preference (https://github.com/alacritty/alacritty/issues/62).
 
 **TIP:** Non-leader keybindings (for e.g. `<C-\>`, mentioned below and others) can be viewed
 by pressing `<backspace>` in the which-key main menu (first popup after pressing `<leader>`)


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->

I noticed that on macOS using Alacritty, the Option-key doesn't work out-of-the-box as meta-key.
Although not necessarily a LunarVim (or Neovim) issue, the docs currently already include a tip to configure iTerm2 so I thought it'd be nice to also include the instructions to configure Alacritty.