### PR TITLE
docs(zh-Hans): fix typo

### DIFF
--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/linting-and-formatting.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/linting-and-formatting.md
@@ -61,7 +61,7 @@ code_actions.setup {
    linters.setup { { command = "flake8", filetypes = { "python" } } }
    ```
 
-## 报错时格式化
+## 保存时格式化
 
 - 要在保存时启用格式化：
 


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
