### PR TITLE
docs: add examples to run dev mode

### DIFF
--- a/docs/configuration/plugins/plugins.md
+++ b/docs/configuration/plugins/plugins.md
@@ -89,12 +89,10 @@ A plugin's README (and `docs/` folder if it exists) typically contain excellent 
 ### Pinning
 
 Versions of core plugins are pinned for better stability,
-you can disable pinning by setting an environment variable `$LVIM_DEV_MODE`, e.g. can be defined in `~/.local/bin/lvim`
+you can disable pinning by setting an environment variable `$LVIM_DEV_MODE`, e.g. can be defined in `~/.local/bin/lvim` or in your shell's rc file:
 
-```
-e.g.
-set LVIM_DEV_MODE=1 in shellrc
-or 
-make a alias in your shellrc
+```bash
+export LVIM_DEV_MODE=1
+# or 
 alias lvim="LVIM_DEV_MODE=1 lvim"
 ```

--- a/docs/configuration/plugins/plugins.md
+++ b/docs/configuration/plugins/plugins.md
@@ -90,3 +90,11 @@ A plugin's README (and `docs/` folder if it exists) typically contain excellent 
 
 Versions of core plugins are pinned for better stability,
 you can disable pinning by setting an environment variable `$LVIM_DEV_MODE`, e.g. can be defined in `~/.local/bin/lvim`
+
+```
+e.g.
+set LVIM_DEV_MODE=1 in shellrc
+or 
+make a alias in your shellrc
+alias lvim="LVIM_DEV_MODE=1 lvim"
+```


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
