### PR TITLE
docs(installation): fix typo

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -13,7 +13,7 @@ sidebar_position: 1
 
 ## Optional Feature Prerequisites
 
-- Install [`lazygit`](https://github.com/jesseduffield/lazygit#installation). This enables `<leader>gg` to launch `lazygit` for intergrated and enhanced Git experience while in `lvim`.
+- Install [`lazygit`](https://github.com/jesseduffield/lazygit#installation). This enables `<leader>gg` to launch `lazygit` for integrated and enhanced Git experience while in `lvim`.
 
 ## Release
 


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
