### PR TITLE
docs(zh-Hans): fix typo and sync en

### DIFF
--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/custom-snippets.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/custom-snippets.md
@@ -52,11 +52,11 @@ sidebar_position: 3
 }
 ```
 
-以上配置将`hellp`展开为`print("Hello, World!")`。
+以上配置将`hello`展开为`print("Hello, World!")`。
 
 ### lua版本
 
-首先在`config.lua`目录创建一个名为`luasnippets`的文件夹：`~/.config/lvim/snippets/`
+首先在`config.lua`目录创建一个名为`luasnippets`的文件夹：`~/.config/lvim/luasnippets/`
 
 然后在该文件夹中，创建一个lua文件，以你想创建代码模版的语言命名。例如，为了创建lua的代码模版，创建一个名为`lua.lua`的（多余但正确的）文件。然后把你的文件放进去，例如：
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/language-servers.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/language-servers.md
@@ -52,7 +52,7 @@ lvim.lsp.automatic_servers_installation = false
 
 例子:
 
-- 使用j `jedi_language_server` 而不是 `pyright`
+- 使用 `jedi_language_server` 而不是 `pyright`
 
   ```lua
   -- add `pyright` to `skipped_servers` list

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/linting-and-formatting.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/language-features/linting-and-formatting.md
@@ -6,8 +6,7 @@ sidebar_position: 2
 
 如果设置一个格式化器，将覆盖语言服务器本身的格式化能力。
 
-最简单的方法是通过名字来引用 linter/formatter/code_actions。请参阅[null-ls
-文档](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md)，了解带有名称的完整内置程序列表。
+最简单的方法是通过名字来引用 linter/formatter/code_actions。请参阅[null-ls 文档](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md)，了解带有名称的完整内置程序列表。
 
 例子:
 
@@ -88,7 +87,7 @@ LunarVim支持所有定义为null-ls的内建程序的linters和formatters，然
 
 :::
 
-面是一个注册[htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier)formatter的例子
+下面是一个注册[htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier)formatter的例子
 
 ```lua
 local helpers = require("null-ls.helpers")

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/faq.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/faq.md
@@ -7,6 +7,20 @@ sidebar_position: 4
 
 ## 该如何 [..] ?
 
+### 如何在 Neovide 中使用 LunarVim？
+
+使用此 bash 脚本启动 neovide
+```shell
+#!/usr/bin/env bash
+
+export LUNARVIM_RUNTIME_DIR="${LUNARVIM_RUNTIME_DIR:-"$HOME/.local/share/lunarvim"}"
+export LUNARVIM_CONFIG_DIR="${LUNARVIM_CONFIG_DIR:-"$HOME/.config/lvim"}"
+export LUNARVIM_CACHE_DIR="${LUNARVIM_CACHE_DIR:-"$HOME/.cache/lvim"}"
+export LUNARVIM_BASE_DIR="${LUNARVIM_BASE_DIR:-"$HOME/.local/share/lunarvim/lvim"}"
+
+exec neovide -- -u "$LUNARVIM_BASE_DIR/init.lua" "$@"
+```
+
 ### 该如何添加自己的键位映射?
 
 - 使用`<leader>Lk`查看所有默认的键位映射
@@ -58,6 +72,7 @@ C/C++语言有`llvm`项目的`clangd`，它可以使用其附加的`clang-tidy`�
 
 如果你想有配置LunarVim的灵感，可以参考这些仓库：
 
+- starter.lvim [https://github.com/LunarVim/starter.lvim](https://github.com/LunarVim/starter.lvim)（特定于语言的lunarvim配置的集合）
 - Chris - [https://github.com/ChristianChiarulli/lvim](https://github.com/ChristianChiarulli/lvim)
 - Abouzar -[ https://github.com/abzcoding/lvim ](https://github.com/abzcoding/lvim)
 - Nelson -[ https://github.com/rebuilt/lvim ](https://github.com/rebuilt/lvim)

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/appearance/colorschemes.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/appearance/colorschemes.md
@@ -27,6 +27,27 @@ lvim.colorscheme = 'desert'
 
 [此列表](https://github.com/rockerBOO/awesome-neovim#colorscheme) 有带tree-sitter支持的配色方案。
 
+## 定制一些颜色
+
+您可以通过在自动命令中覆盖它们来自定义突出显示组。要查找要更改的组，请使用 `leader s H` (`:Telescope highlights`)、 `:TSHighlightCapturesUnderCursor` 或 `:Inspect`
+```lua
+lvim.autocommands = {
+  {
+    { "ColorScheme" },
+    {
+      pattern = "*",
+      callback = function()
+        -- change `Normal` to the group you want to change
+        -- and `#ffffff` to the color you want
+        -- see `:h nvim_set_hl` for more options
+        vim.api.nvim_set_hl(0, "Normal", { bg = "#ffffff", underline = false, bold = true })
+      end,
+    },
+  },
+}
+
+```
+
 ## 透明窗口
 
 如果您在使用透明的窗口，需要打开这个设置：

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/appearance/statusline.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/appearance/statusline.md
@@ -36,7 +36,7 @@ lvim.builtin.lualine.style = "default" -- or "none"
 **LunarVim的组件**
 
 `mode`, `branch`, `filename`, `diff`, `python_env`, `diagnostics`, `treesitter`, `lsp`, `location`, `progress`, `spaces`, `encoding`, `filetype`, `scrollbar`
-`
+
 设置 `lualine` 的 `"diff"` 组件到 `"default"` 风格的c部分：
 
 ```lua

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/keybindings.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/keybindings.md
@@ -124,7 +124,7 @@ lvim.builtin.which_key.mappings["tP"] = {
 }
 ```
 
-### 字目录映射
+### 子目录映射
 
 映射一组键位。按`<Leader>td`会触发`Definitions`。该目录的目录名会显示为`Trouble`：
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/plugins/core-plugins.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/plugins/core-plugins.md
@@ -3,24 +3,25 @@ sidebar_position: 1
 ---
 
 # 核心插件
+核心插件的配置可通过 `lvim.builtin` 表访问。
 
-_This page is not complete, [you can help us write it](https://github.com/LunarVim/lunarvim.org/issues/352)_
-
-The configurations for core plugins are accessible through `lvim.builtin`. Most should contain an `active` attribute that can be set to `false` to disable the plugin
+## 禁用核心插件
+大多数应该包含一个 `active` 属性，可以将其设置为 `false` 以禁用插件
 
 ```lua
 lvim.builtin.alpha.active = true
-lvim.builtin.dap.active = true -- (default: false)
-lvim.builtin.terminal.active = true
+lvim.builtin.dap.active = true 
 ```
 
 :::caution
 
-Disabling a plugin will not take effect until you restart lvim.
+禁用插件只有重新启动 lvim 才会生效。
 
 :::
 
-You can press `<TAB>` to get autocomplete suggestions to explore these settings.
+## 配置核心插件
+
+要配置内置插件，请编辑 `lvim.builtin.<builtin>` 中的选项。您可以按 `<TAB>` 获取自动完成建议以探索这些设置。
 
 ```lua
 lvim.builtin.cmp.completion.keyword_length = 2
@@ -29,12 +30,10 @@ lvim.builtin.telescope.defaults.layout_config.preview_cutoff = 75
 ```
 
 :::tip
-
-A plugin's README (and `docs/` folder if it exists) typically contain excellent documentation, so it may be worthwhile to create an alias for if you use them often.
+插件的 README（以及 `docs/` 文件夹，如果存在）通常包含优秀的文档，因此如果您经常使用它们，创建别名可能是值得的。
 
 :::
 
 ## Pinning
 
-Versions of core plugins are pinned for better stability,
-you can disable pinning by setting an environment variable `$LVIM_DEV_MODE`, e.g. can be defined in `~/.local/bin/lvim`
+核心插件的版本被固定以获得更好的稳定性，您可以通过设置环境变量 `$LVIM_DEV_MODE` 来禁用固定，例如可以在 `~/.local/bin/lvim` 中定义

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/plugins/user-plugins.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/plugins/user-plugins.md
@@ -17,7 +17,7 @@ lvim.plugins = {
 	},
 }
 ```
-检查[示例配置](../example-configurations.md)以获取一些建议。
+检查[示例配置](/configuration/plugins/example-configurations.md)以获取一些建议。
 
 :::tip
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/plugins/user-plugins.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.3/configuration/plugins/user-plugins.md
@@ -4,11 +4,9 @@ sidebar_position: 2
 
 # 用户插件
 
-_This page is not complete, [you can help us write it](https://github.com/LunarVim/lunarvim.org/issues/352)_
+可以通过将条目添加到 `config.lua` 文件中的 `lvim.plugins` 表来安装用户插件，保存或手动调用 `LvimReload` 将触发延迟同步该文件中的所有插件。
 
-User plugins can be installed by adding entries to the `lvim.plugins` table in your `config.lua` file,
-and saving or manually invoking `LvimReload` will trigger lazy to sync all the plugins in that table.
-
+例子：
 ```lua
 lvim.plugins = {
 	{ "lunarvim/colorschemes" },
@@ -19,14 +17,11 @@ lvim.plugins = {
 	},
 }
 ```
+检查[示例配置](../example-configurations.md)以获取一些建议。
 
 :::tip
 
-You can find all available options [here](https://github.com/folke/lazy.nvim#-plugin-spec) or in lunarvim: `:help lazy.nvim-plugin-spec`
-You can find more examples [here](https://github.com/folke/lazy.nvim#examples)
+从 `lvim.plugins` 表中删除插件会将其从您的配置中删除，但不会从您的系统中删除。要完全删除它们，请运行 `:Lazy clean`
 
 :::
 
-Check the [extra plugins](./example-configurations.md) for some suggestions.
-
-_Note: removing a plugin from the `lvim.plugins` table removes it from your configuration but not your system. To remove them completely, run `:Lazy clean`._


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
