### PR TITLE
docs(gitblame): Use `setup`

### DIFF
--- a/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
@@ -312,7 +312,7 @@ vim.keymap.set('n', ',W', swap_windows, { desc = 'Swap windows' })
   event = "BufRead",
   config = function()
     vim.cmd "highlight default link gitblame SpecialComment"
-    vim.g.gitblame_enabled = 0
+    require("gitblame").setup { enabled = false }
   end,
 },
 ```


### PR DESCRIPTION
There was an [issue](https://github.com/f-person/git-blame.nvim/issues/65) on git-blame.nvim about `vim.g.gitblame_disable = 0` not working with Lunar.

I recently implemented a setup function which solves this issue. This commit uses `setup`, instead of legacy vim.g in order to avoid any confusions for users who wanna use git-blame :).