### PR TITLE
docs(keybinds-overview): completion select previous & next item key

### DIFF
--- a/docs/beginners-guide/keybinds-overview.md
+++ b/docs/beginners-guide/keybinds-overview.md
@@ -62,8 +62,8 @@ by pressing `<backspace>` in the which-key main menu (first popup after pressing
 | `<C-space>`                | show completion menu                   | insert |
 | `<CR>` `<C-y>`             | confirm                                | insert |
 | `<C-e>`                    | abort                                  | insert |
-| `<C-k>` `<Up>` `<Tab>`     | select previous item                   | insert |
-| `<C-j>` `<Down>` `<S-Tab>` | select next item                       | insert |
+| `<C-k>` `<Up>` `<S-Tab>`   | select previous item                   | insert |
+| `<C-j>` `<Down>` `<Tab>`   | select next item                       | insert |
 | `<C-d>`                    | scroll docs up                         | insert |
 | `<C-f>`                    | scroll docs down                       | insert |
 | `<CR>` `<Tab>`             | jump to next jumpable in a snippet     | insert |

--- a/versioned_docs/version-1.2/keybind-overview.md
+++ b/versioned_docs/version-1.2/keybind-overview.md
@@ -56,8 +56,8 @@ by pressing `<backspace>` in the which-key main menu (first popup after pressing
 | `<C-space>`                | show completion menu                   | insert |
 | `<CR>` `<C-y>`             | confirm                                | insert |
 | `<C-e>`                    | abort                                  | insert |
-| `<C-k>` `<Up>` `<Tab>`     | select previous item                   | insert |
-| `<C-j>` `<Down>` `<S-Tab>` | select next item                       | insert |
+| `<C-k>` `<Up>` `<S-Tab>`   | select previous item                   | insert |
+| `<C-j>` `<Down>` `<Tab>`   | select next item                       | insert |
 | `<C-d>`                    | scroll docs up                         | insert |
 | `<C-f>`                    | scroll docs down                       | insert |
 | `<CR>` `<Tab>`             | jump to next jumpable in a snippet     | insert |

--- a/versioned_docs/version-1.3/beginners-guide/keybinds-overview.md
+++ b/versioned_docs/version-1.3/beginners-guide/keybinds-overview.md
@@ -62,8 +62,8 @@ by pressing `<backspace>` in the which-key main menu (first popup after pressing
 | `<C-space>`                | show completion menu                   | insert |
 | `<CR>` `<C-y>`             | confirm                                | insert |
 | `<C-e>`                    | abort                                  | insert |
-| `<C-k>` `<Up>` `<Tab>`     | select previous item                   | insert |
-| `<C-j>` `<Down>` `<S-Tab>` | select next item                       | insert |
+| `<C-k>` `<Up>` `<S-Tab>`   | select previous item                   | insert |
+| `<C-j>` `<Down>` `<Tab>`   | select next item                       | insert |
 | `<C-d>`                    | scroll docs up                         | insert |
 | `<C-f>`                    | scroll docs down                       | insert |
 | `<CR>` `<Tab>`             | jump to next jumpable in a snippet     | insert |


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->

This is my first pull request. if there is something wrong, do let me know. Thank you