### PR TITLE
fixed navbar top gap

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -146,4 +146,6 @@ iframe[src*='youtube.com'] {
 
 .navbar--fixed-top {
   z-index: calc(var(--ifm-z-index-fixed) + 2);
+  top: -1px;
 }
+


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
In your docusaurus config you're setting the hideOnScroll of the Navbar to false so that the navbar is sticky, and apperently there is a bug in docusaurus that makes a 1px gap apear on top of the navbar in this situation on some zoom levels( like 125% in my case), so when the user scrolls the content behind the navbar could be seen through that gap, like you can see in this picture:

![Example](https://github.com/LunarVim/lunarvim.org/assets/25662092/b077311d-aa71-42b5-a37e-f455e50f5951)

This behavior is well documented in this stackoverflow question: https://stackoverflow.com/questions/64729642/css-sticky-ignores-1px

The root of the problem is the combination of position sticky and top 0, the solution is to simply add a top of -1px to the navbar to compensate for the gap, it's the only thing I added as you can already see.