### PR TITLE
chore: run replaced with build

### DIFF
--- a/versioned_docs/version-1.2/plugins/extra-plugins.md
+++ b/versioned_docs/version-1.2/plugins/extra-plugins.md
@@ -821,7 +821,7 @@ table.insert(lvim.builtin.cmp.sources, 1, { name = "copilot" })
 ```lua
 {
   "iamcco/markdown-preview.nvim",
-  run = "cd app && npm install",
+  build = "cd app && npm install",
   ft = "markdown",
   config = function()
     vim.g.mkdp_auto_start = 1


### PR DESCRIPTION
the command was switched from run to build

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
