### PR TITLE
fix: Fix auto-session example using non-maintained version of auto-session

### DIFF
--- a/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
@@ -682,9 +682,15 @@ lvim.builtin.which_key.mappings["t"] = {
 
 ```lua
 {
-  "Pocco81/auto-save.nvim",
+  "okuuva/auto-save.nvim",
   config = function()
-    require("auto-save").setup()
+    require("auto-save").setup({
+      -- Optionally add the following trigger_events to prevent auto save on InsertLeave
+      trigger_events = {
+        immediate_save = { "BufLeave", "FocusLost" },
+        defer_save = {},
+      },
+    })
   end,
 },
 ```


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
