### PR TITLE
docs(fix): update reference to disable automatic installation of lsp

### DIFF
--- a/docs/configuration/language-features/language-servers.md
+++ b/docs/configuration/language-features/language-servers.md
@@ -29,7 +29,7 @@ configure it automatically for you.
 ### Manual installation
 
 ```lua
-lvim.lsp.automatic_servers_installation = false
+lvim.lsp.installer.setup.automatic_installation = false
 ```
 
 Please refer to [mason](https://github.com/williamboman/mason.nvim) to see the updated full list of


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
This update the reference to allow manual installation of lsp servers from `lvim.lsp.automatic_servers_installation` to `.installer.setup.automatic_installation`.
