### PR TITLE
docs(Autocommands): Remember cursor postion

### DIFF
--- a/docs/configuration/autocommands.md
+++ b/docs/configuration/autocommands.md
@@ -47,3 +47,18 @@ lvim.autocommands = {
   }
 }
 ```
+
+A popular feature of Vim is to remember the cursor position. You can achieve similar functionality with the following:
+
+```lua
+lvim.autocommands = {
+    {
+        "BufWinEnter",
+        {
+            -- Remember cursor position
+            pattern = "*",
+            command = 'silent! normal! g`"zv',
+        },
+    }
+}
+```


### PR DESCRIPTION
Former users of Vim may have become accustomed to the editor remembering the cursor position.

This commit adds an example to the documentation to provide similar functionality.

I applied this autocommand to my lvim setup and believe that this example may be useful to the wider lvim community.

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
