### PR TITLE
docs(docs & versioned_docs): add ripgrep dependency in prerequisites

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Prerequisites
 
 - Make sure you have installed the latest version of [`Neovim v0.9.0+`](https://github.com/neovim/neovim/releases/latest).
-- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/) and [`cargo`](https://www.rust-lang.org/tools/install) installed on your system.
+- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/), [`cargo`](https://www.rust-lang.org/tools/install) and [`ripgrep`](https://github.com/BurntSushi/ripgrep) installed on your system.
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (for Windows).
 

--- a/versioned_docs/version-1.3/installation/installation.md
+++ b/versioned_docs/version-1.3/installation/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Prerequisites
 
 - Make sure you have installed the latest version of [`Neovim v0.9.0+`](https://github.com/neovim/neovim/releases/latest).
-- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/) and [`cargo`](https://www.rust-lang.org/tools/install) installed on your system.
+- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/), [`cargo`](https://www.rust-lang.org/tools/install) and [`ripgrep`](https://github.com/BurntSushi/ripgrep) installed on your system.
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (for Windows)
 


### PR DESCRIPTION
Updated the [Website Installation page](https://www.lunarvim.org/docs/installation) by incorporating the essential dependency, [ripgrep](https://github.com/BurntSushi/ripgrep) as it is a prerequisite for utilizing the find_file option showcased in lvim, as documented in [Telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).