### PR TITLE
Fixed documentation for lsp_signature plugin

### DIFF
--- a/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.3/configuration/plugins/example-configurations.md
@@ -628,12 +628,25 @@ end
 
 **hint when you type**
 
+Add to plugins section:
 ```lua
-{
-  "ray-x/lsp_signature.nvim",
-  event = "BufRead",
-  config = function() require"lsp_signature".on_attach() end,
-},
+{ 
+    "ray-x/lsp_signature.nvim",
+    config = function()
+      require"lsp_signature".setup({
+        -- …
+      })
+    end,
+}, 
+```
+
+And after activate plugin anywhere in config.lua:
+```lua
+lvim.lsp.on_attach_callback = function(client, bufnr)
+  -- …
+  require"lsp_signature".on_attach()
+  -- …
+end
 ```
 
 ### [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim)


### PR DESCRIPTION
Fixed docs related to `lsp_signature` plugin installation. Current live version of docs have incorrect instructions that no longer work.

Fix was taken from this [comment](https://github.com/ray-x/lsp_signature.nvim/issues/202#issuecomment-1190525409) (thanks to @FelipeLema)