### PR TITLE
docs(installation): add non-interactive info for linux

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -30,6 +30,14 @@ import TabItem from '@theme/TabItem';
 ```bash
 LV_BRANCH='master' bash <(curl -s https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.sh)
 ```
+To achieve a non-interactive installation, you can supply flags to the installer. For example, to always install dependencies, the `--install-dependencies` flag can be supplied:
+```bash
+LV_BRANCH='release-1.4/neovim-0.9' bash <(curl -s https://raw.githubusercontent.com/LunarVim/LunarVim/release-1.4/neovim-0.9/utils/installer/install.sh) -s -- --install-dependencies
+```
+A list of all installation flags can be found by supplying `-h` (or `--help`):
+```bash
+LV_BRANCH='release-1.4/neovim-0.9' bash <(curl -s https://raw.githubusercontent.com/LunarVim/LunarVim/release-1.4/neovim-0.9/utils/installer/install.sh) -s -- -h
+```
 
 </TabItem>
 <TabItem value="windows" label="Windows">
@@ -61,6 +69,14 @@ All the new features with all the new bugs:
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)
+```
+To achieve a non-interactive installation, you can supply flags to the installer. For example, to always install dependencies, the `--install-dependencies` flag can be supplied:
+```bash
+bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh) -s -- --install-dependencies
+```
+A list of all installation flags can be found by supplying `-h` (or `--help`):
+```bash
+bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh) -s -- -h
 ```
 
 </TabItem>


### PR DESCRIPTION
hallo! o( ˶^▾^˶ )o

as a user, i want to install lunarvim non-interactively so that i can use the installer in my dotfiles. i was shown that the installer has the ability to do this via [the code](https://github.com/LunarVim/LunarVim/blob/master/utils/installer/install.sh#L54-L63) (thank you @titaniumtraveler ❤️)

this pr adds a blurb about the installation flags on linux. it also provides a code example on how to pass them to the provided one-liner, since i feel like that is non-trivial c:

