### PR TITLE
update install pre-requisites

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Prerequisites
 
 - Make sure you have installed the latest version of [`Neovim v0.9.5+`](https://github.com/neovim/neovim/releases/latest).
-- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/), [`cargo`](https://www.rust-lang.org/tools/install) and [`ripgrep`](https://github.com/BurntSushi/ripgrep) installed on your system.
+- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/), [`unzip`](https://launchpad.net/unzip), [`cargo`](https://www.rust-lang.org/tools/install) and [`ripgrep`](https://github.com/BurntSushi/ripgrep) installed on your system.
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (for Windows).
 
@@ -88,9 +88,9 @@ Make sure to check the [troubleshooting](../troubleshooting/README.md) section i
 
 ## Updating LunarVim
 
-- LunarVim updates to the current LunarVim branch's latest commit.  
+- LunarVim updates to the current LunarVim branch's latest commit.
 - `:LvimUpdate` command in command-line mode.
-- `<leader>Lu` using WhichKey.  
+- `<leader>Lu` using WhichKey.
 - From the command-line `lvim +LvimUpdate +q`
 
 ### Update the plugins

--- a/i18n/es/docusaurus-plugin-content-docs/current/installation/installation.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/installation/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Requisitos Previos
 
 - Asegúrate de tener instalado la última versión de [`Neovim v0.8.0+`](https://github.com/neovim/neovim/releases/latest).
-- Debes tener `git`, `make`, `pip`, `npm`, `node` y `cargo` instalados en tu sistema.
+- Debes tener `git`, `make`, `pip`, `npm`, `node`, `unzip` y `cargo` instalados en tu sistema.
 - [Resolver permisos `EACCES` al instalar paquetes globalmente](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) para evitar errores al instalar paquetes con npm.
 
 ## Ultima Versión Estable

--- a/i18n/uk/docusaurus-plugin-content-docs/current/installation/installation.md
+++ b/i18n/uk/docusaurus-plugin-content-docs/current/installation/installation.md
@@ -4,14 +4,14 @@ sidebar_position: 1
 
 # Установлення
 
-## Передумови 
+## Передумови
 
 - Упевніться, що ви встановили останюю версію [`Neovim v0.9.0+`](https://github.com/neovim/neovim/releases/latest).
-- [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/) та [`cargo`](https://www.rust-lang.org/tools/install) мають бути встановлені на вашій системі.
+- [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/), [`unzip`](https://launchpad.net/unzip) та [`cargo`](https://www.rust-lang.org/tools/install) мають бути встановлені на вашій системі.
 - [Вирішення проблеми з дозволами `EACCES` під час глобального встановлення пакунків](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) щоб уникнути помилок під час встановлення пакетів за допомогою npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (для Windows).
 
-## Передумови для додаткових функцій 
+## Передумови для додаткових функцій
 - Установіть [`lazygit`](https://github.com/jesseduffield/lazygit#installation). Це дозволяє `<leader>gg` запускати `lazygit` для інтегрованого та розширеного використання Git'а, перебуваючи у `lvim`.
 
 
@@ -88,16 +88,16 @@ docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep a
 
 ## Оновлення LunarVim
 
-- LunarVim оновлюється до поточного останнього коміта гілки LunarVim.  
+- LunarVim оновлюється до поточного останнього коміта гілки LunarVim.
 - `:LvimUpdate` команда в режимі командного рядка.
-- `<leader>Lu` використовуючи WhichKey.  
+- `<leader>Lu` використовуючи WhichKey.
 - З командного рядка `lvim +LvimUpdate +q`
 
 ### Оновлення плагінів
 
 - Усередині LunarVim `:LvimSyncCorePlugins`
 
-## Видалення 
+## Видалення
 
 Ви можете видалити LunarVim (включаючи файли налаштувань) використовуючи вбудований `uninstall` скрипт
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/installation.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## 前置条件
 
 - 请确保拥有最新版本的 [`Neovim v0.9.5+`](https://github.com/neovim/neovim/releases/latest)。
-- 在您的系统上安装 [`git`](https://cli.github.com/)、[`make`](https://www.gnu.org/software/make/)、[`pip`](https://pypi.org/project/pip/)、[`python`](https://www.python.org/)、[`npm`](https://npmjs.com/)、[`node`](https://nodejs.org/) 和 [`cargo`](https://www.rust-lang.org/tools/install)。
+- 在您的系统上安装 [`git`](https://cli.github.com/)、[`make`](https://www.gnu.org/software/make/)、[`pip`](https://pypi.org/project/pip/)、[`python`](https://www.python.org/)、[`npm`](https://npmjs.com/)、[`node`](https://nodejs.org/)、['unzip'](https://launchpad.net/unzip) 和 [`cargo`](https://www.rust-lang.org/tools/install)。
 - [解决全局安装程序包时的 `EACCES` 权限错误](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)，以避免使用 npm 安装程序包时出错。
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2)（Windows系统所需）。
 
@@ -89,7 +89,7 @@ docker run -w /root -it --rm alpine:edge sh -uelic 'apk add git neovim ripgrep a
 ## 更新LunarVim
 
 
-- 将 LunarVim 更新到当前 LunarVim 分支的最新提交。 
+- 将 LunarVim 更新到当前 LunarVim 分支的最新提交。
 - 在命令行模式中使用 `:LvimUpdate` 命令。
 - 按下 `<leader>Lu` 使用 WhichKey。
 - 从命令行 `lvim +LvimUpdate +q`

--- a/versioned_docs/version-1.4/installation/installation.md
+++ b/versioned_docs/version-1.4/installation/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Prerequisites
 
 - Make sure you have installed the latest version of [`Neovim v0.9.0+`](https://github.com/neovim/neovim/releases/latest).
-- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/), [`cargo`](https://www.rust-lang.org/tools/install) and [`ripgrep`](https://github.com/BurntSushi/ripgrep) installed on your system.
+- Have [`git`](https://cli.github.com/), [`make`](https://www.gnu.org/software/make/), [`pip`](https://pypi.org/project/pip/), [`python`](https://www.python.org/), [`npm`](https://npmjs.com/), [`node`](https://nodejs.org/), [`unzip`](https://launchpad.net/unzip), [`cargo`](https://www.rust-lang.org/tools/install) and [`ripgrep`](https://github.com/BurntSushi/ripgrep) installed on your system.
 - [Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to avoid error when installing packages with npm.
 - [`PowerShell 7+`](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2) (for Windows).
 


### PR DESCRIPTION
<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->

Many of the lsp needs unzip. This means that `unzip` binary is dependency for many of them.