### PR TITLE
docs(plugins/example-configurations): Update example-configurations.md

### DIFF
--- a/versioned_docs/version-1.4/configuration/plugins/example-configurations.md
+++ b/versioned_docs/version-1.4/configuration/plugins/example-configurations.md
@@ -430,18 +430,12 @@ vim.keymap.set('n', ',W', swap_windows, { desc = 'Swap windows' })
 
 **rainbow parentheses**
 
+Note: This is no longer maintained. Please use `hiphish/rainbow-delimiters.nvim`
+
 ```lua
 {
-  "mrjones2014/nvim-ts-rainbow",
+  "hiphish/rainbow-delimiters.nvim",
 },
-```
-
-After installing ensure to enable it in your `config.lua` using:
-
-```
-...
-lvim.builtin.treesitter.rainbow.enable = true
-...
 ```
 
 ### [playground](https://github.com/nvim-treesitter/playground)


### PR DESCRIPTION
Updated plugin nvim-ts-rainbow as deprecated
Suggested hiphish/rainbow-delimiters.nvim

<!-- This won't be rendered
[CHECKLIST]
I have read the [contributing guidelines](https://github.com/LunarVim/lunarvim.org/blob/master/CONTRIBUTING.md)
I prefixed the title with one of the following tags:
 - docs: on documentation updates
 - fix: when fixing a functionality (e.g. broken links)
 - feat: for feature addition / improvements (e.g. accessibility improvement)
 - refactor: when moving code without adding any functionality
 - [...] more in the contributing guidelines
example: docs(installation): update install command for windows

[IMPORTANT]
Our docs are versioned:
- files in `/docs` are for the next version, you most likely want to edit files in this folder
- files in `/versioned-docs` are frozed docs for current and older versions, edits here won't be included in the next version
-->
